### PR TITLE
Status: fix source status adding secret retrieval

### DIFF
--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -17,5 +17,4 @@ kind: Namespace
 metadata:
   name: knative-sources
   labels:
-    istio-injection: enabled
     contrib.eventing.knative.dev/release: devel

--- a/pkg/reconciler/slack/controller.go
+++ b/pkg/reconciler/slack/controller.go
@@ -49,6 +49,8 @@ func NewController(
 	slackSourceInformer := slacksourceinformer.Get(ctx)
 
 	r := &Reconciler{
+		kubeClientSet: kubeclient.Get(ctx),
+
 		dr:  &reconciler.DeploymentReconciler{KubeClientSet: kubeclient.Get(ctx)},
 		sbr: &reconciler.SinkBindingReconciler{EventingClientSet: eventingclient.Get(ctx)},
 	}


### PR DESCRIPTION
Slack token secret was not taken into account for the Slack CRD status.
