### PR TITLE
CRD: unify event type

### DIFF
--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -12,7 +12,7 @@ metadata:
   annotations:
     registry.knative.dev/eventTypes: |
       [
-        { "type": "dev.knative.sources.slack/new-message" },
+        { "type": "dev.knative.sources.slack/message" },
       ]
 spec:
   group: sources.knative.dev

--- a/pkg/adapter/slack.go
+++ b/pkg/adapter/slack.go
@@ -89,6 +89,6 @@ func (p *defaultProcessor) cloudEventFromMessage(message *slack.MessageEvent) *c
 		UserID: message.User,
 		Text:   message.Text,
 	})
-	event.SetType("dev.knative.sources.slack/" + message.Type)
+	event.SetType("dev.knative.sources.slack/message")
 	return &event
 }


### PR DESCRIPTION
There was a mismatch with event types naming.

Resolving, event type is `dev.knative.sources.slack/message` for any message received from the RTM API