### PR TITLE
ci: adapt to `master` only workflow on `config` repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
           working_directory: tmconfig/
           command: |
             git add overlays
-            git commit -m "Update overlays/<< parameters.cluster >>/triggerflow manifest to '${CIRCLE_TAG:-${CIRCLE_SHA1}}'"
+            git commit -m "Update overlays/<< parameters.cluster >>/sources deployment to '${CIRCLE_TAG:-${CIRCLE_SHA1}}'"
             git push origin master
 
   release:


### PR DESCRIPTION
- ci: switch to master only config updates
- ci: remove dependence on .PATTERN file
- Use sed expression to update image tag

depends on https://github.com/triggermesh/config/pull/130