### PR TITLE
Docs: update docs and config manifests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,113 @@
+# Development
+
+## Contents
+
+- [Development](#development)
+  - [Contents](#contents)
+  - [Building](#building)
+  - [Running the controller](#running-the-controller)
+    - [Locally](#locally)
+    - [Inside a cluster](#inside-a-cluster)
+  - [Adding event sources](#adding-event-sources)
+
+## Building
+
+Triggermesh Knative Sources use:
+
+- make
+- go 1.14
+- go modules
+
+Makefile `help` flag shows all targets per Source
+
+```sh
+$ make help
+
+Triggermesh Slack Event Source for Knative
+Usage:
+  make <source>
+  help                 Display this help
+  mod-download         Download go modules
+  build                Build the binary
+  release              Build release binaries
+  test                 Run unit tests
+  cover                Generate code coverage
+  lint                 Lint source files
+  vet                  Vet source files
+  fmt                  Format source files
+  fmt-test             Check source formatting
+  image                Builds the container image
+  cloudbuild-test      Test container image build with Google Cloud Build
+  cloudbuild           Build and publish image to GCR
+  clean                Clean build artifacts
+  gen-all              Generate all
+  gen-deepcopy         Generate deepcopy for API objects
+  gen-client           Generate clientset for API objects
+  gen-lister           Generate listers for API objects
+  gen-informer         Generate informers for API objects
+  gen-injection        Generate injection for API objects
+  gen-crd              Generate CRD manifests for API objects
+```
+
+
+## Running the controller
+
+### Locally
+
+Providing that the local environment is configured with a valid kubeconfig (either in `~/.kube/config` or set via the
+`KUBECONFIG` environment variable), running the controller locally from the current development branch is as simple as
+executing
+
+```sh
+go run ./cmd/controller
+```
+
+> :information_source: The source controller requires a few environment variables to be exported in order to start.
+>
+> `SYSTEM_NAMESPACE`
+>
+> The namespace in which the controller sources its configuration from (logging, observability). This can potentially be
+> set to any namespace, including `default`, since the controller falls back to a default configuration if the
+> aforementioned ConfigMaps are missing.
+>
+> `METRICS_DOMAIN`
+>
+> The domain to use for surfacing metrics.
+>
+> **Optional**. Only required when a ConfigMap for observability (`config-observability` by default) actually exists in
+> the namespace defined by `SYSTEM_NAMESPACE`.
+
+### Inside a cluster
+
+One can build/push container images and deploy all relevant Kubernetes objects to a running cluster in a single command
+using [ko](https://github.com/google/ko).
+
+```sh
+$ ko apply --local -f ./config/
+...
+2020/04/07 13:44:00 Using base gcr.io/distroless/static:latest for github.com/triggermesh/knative-sources/slack/cmd/controller
+2020/04/07 13:44:01 Building github.com/triggermesh/knative-sources/slack/cmd/controller
+2020/04/07 13:44:05 Loading ko.local/slack-controller-0d0554a556
+2020/04/07 13:44:06 Loaded ko.local/slack-source-controller-0d0554a556
+2020/04/07 13:44:06 Adding tag latest
+2020/04/07 13:44:06 Added tag latest
+deployment.apps/slack-source-controller created
+```
+
+The controller will be deployed to the `triggermesh` namespace.
+
+```console
+$ kubectl -n triggermesh get deployment/slack-source-controller
+NAME                           READY   UP-TO-DATE   AVAILABLE   AGE
+slack-source-controller   1/1     1            1           1m
+```
+
+> :information_source: Although `ko` does not make use of the `docker` client, the `--local` flag assumes the
+> development environment is properly configured to import images in a Docker daemon. On `minikube`, for example, it is
+> assumed that the environment variables defined by `minikube docker-env` are exported.
+>
+> Please refer to the `ko` documentation for further usage instructions.
+
+## Adding event sources
+
+Refer to Knative's [sample source](https://github.com/knative/sample-source) on how to develop event sources

--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # Triggermesh Sources for Knative
 
-Set of Knative Sources that bring cloud events from external systems.
+These are the set of open Knative Sources that Triggermesh maintains.
+Along with this repository you will find some other Knative Sources we provide semantically grouped at:
+
+- [Knative AWS Sources](https://github.com/triggermesh/aws-event-sources)
+- [Gitlab Source](https://github.com/knative/eventing-contrib/tree/master/gitlab) hosted at Knative project
 
 ## Sources
 
-Sources are located at folders under this repository, each of them containing a README regarding its configuration and deployment.
+Instructions on installing and usage can be found at each individual event source sub-directory.
+
+| Source | Support level |
+|-------------|---------------|
+| [Slack](https://github.com/triggermesh/knative-sources/tree/master/slack)  | alpha         |
+
+## TriggerMesh Cloud Early Access
+
+Triggermesh Knative Sources can be used as is from this repo. You can also use them along with other components from our Cloud [https://cloud.triggermesh.io](https://cloud.triggermesh.io) where we have developed an enjoyable UI to configure them.
 
 ## Support
 
-This is heavily **Work In Progress** We would love your feedback on this
-Operator so don't hesitate to let us know what is wrong and how we could improve
-it, just file an [issue](https://github.com/triggermesh/knative-sources/issues/new)
+We would love your feedback and help on these sources, so don't hesitate to let us know what is wrong and how we could improve them, just file an [issue](https://github.com/triggermesh/knative-sources/issues/new) or join those of use who are maintaining them and submit a [PR](https://github.com/triggermesh/knative-sources/compare)
 
 ## Commercial Support
 
@@ -21,3 +31,7 @@ TriggerMesh Inc supports those sources commercially, email info@triggermesh.com 
 This project is by no means part of [CNCF](https://www.cncf.io/) but we abide
 by its
 [code of conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md)
+
+## Contributing
+
+Refer to [DEVELOPMENT.md](./DEVELOPMENT.md).

--- a/slack/README.md
+++ b/slack/README.md
@@ -2,6 +2,16 @@
 
 Slack Source enables integration between slack messages read by a bot users and Knative Eventing.
 
+## Contents
+- [Slack Source for Knative](#slack-source-for-knative)
+  - [Contents](#contents)
+  - [Deployment](#deployment)
+    - [Deploy Knative Slack Source](#deploy-knative-slack-source)
+    - [Create a Slack Bot User](#create-a-slack-bot-user)
+    - [Creating an Slack Source instance](#creating-an-slack-source-instance)
+  - [Events](#events)
+  - [Support](#support)
+
 ## Deployment
 
 ### Deploy Knative Slack Source
@@ -75,3 +85,9 @@ The Slack Source creates a cloud event for each message written at a channel whe
      "text": "<MESSAGE-CONTENTS>"
    }
 ```
+
+## Support
+
+This is heavily **Work In Progress** We would love your feedback on this
+Operator so don't hesitate to let us know what is wrong and how we could improve
+it, just file an [issue](https://github.com/triggermesh/knative-sources/issues/new)

--- a/slack/config/100-namespace.yaml
+++ b/slack/config/100-namespace.yaml
@@ -16,5 +16,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: triggermesh
-  labels:
-    contrib.eventing.knative.dev/release: devel

--- a/slack/config/200-serviceaccounts.yaml
+++ b/slack/config/200-serviceaccounts.yaml
@@ -17,5 +17,3 @@ kind: ServiceAccount
 metadata:
   name: slack-source-controller
   namespace: triggermesh
-  labels:
-    contrib.eventing.knative.dev/release: devel

--- a/slack/config/201-clusterroles.yaml
+++ b/slack/config/201-clusterroles.yaml
@@ -16,8 +16,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: slack-source-controller
-  labels:
-    contrib.eventing.knative.dev/release: devel
 rules:
 - apiGroups:
   - apps
@@ -91,7 +89,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: slack-source-observer
   labels:
-    contrib.eventing.knative.dev/release: devel
     duck.knative.dev/source: "true"
 rules:
 - apiGroups:

--- a/slack/config/202-clusterrolebindings.yaml
+++ b/slack/config/202-clusterrolebindings.yaml
@@ -16,8 +16,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: &app slack-source-controller
-  labels:
-    contrib.eventing.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -33,8 +31,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: slack-source-controller-addressable-resolver
-  labels:
-    contrib.eventing.knative.dev/release: devel
 # An aggregated ClusterRole for all Addressable CRDs.
 # Ref: https://github.com/knative/serving/blob/master/config/core/roles/addressable-resolvers-clusterrole.yaml
 roleRef:

--- a/slack/config/300-crds.yaml
+++ b/slack/config/300-crds.yaml
@@ -17,7 +17,6 @@ kind: CustomResourceDefinition
 metadata:
   name: slacksources.sources.triggermesh.io
   labels:
-    contrib.eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"

--- a/slack/config/500-controller.yaml
+++ b/slack/config/500-controller.yaml
@@ -18,7 +18,6 @@ metadata:
   name: &app slack-source-controller
   namespace: triggermesh
   labels:
-    contrib.eventing.knative.dev/release: devel
     control-plane: slack-source-controller-manager
 spec:
   replicas: 1
@@ -30,7 +29,6 @@ spec:
     metadata:
       labels:
         control-plane: *app
-        contrib.eventing.knative.dev/release: devel
 
     spec:
       serviceAccountName: *app
@@ -41,7 +39,7 @@ spec:
         image: ko://github.com/triggermesh/knative-sources/slack/cmd/controller
         resources:
           requests:
-            cpu: 20m
+            cpu: 50m
             memory: 20Mi
 
         env:


### PR DESCRIPTION
Update docs:
- Improve readme
- Add developer (based on AWS sources doc)
- Add TOC at Slack readme

Also, set config manifests to match the ones deployed at Triggermesh Cloud