### PR TITLE
Make ticket.id a number attribute

### DIFF
--- a/zendesk/pkg/reconciler/reconciler.go
+++ b/zendesk/pkg/reconciler/reconciler.go
@@ -208,7 +208,7 @@ func (r *reconciler) secretFrom(ctx context.Context, namespace string, secretKey
 
 const triggerPayloadJSON = `{
   "ticket": {
-    "id": "{{ticket.id}}",
+    "id": {{ticket.id}},
     "external_id": "{{ticket.external_id}}",
     "title": "{{ticket.title}}",
     "url": "{{ticket.url}}",


### PR DESCRIPTION
`ticket.id` is a "number" attribute, so we need to unquote it.

Closes #49 