### PR TITLE
Do not retry reconciliation on denied request

### DIFF
--- a/pkg/reconciler/zendesksource/controller.go
+++ b/pkg/reconciler/zendesksource/controller.go
@@ -18,6 +18,7 @@ package zendesksource
 
 import (
 	"context"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 
@@ -32,6 +33,9 @@ import (
 	reconcilerv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/zendesksource"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 )
+
+// the resync period ensures we regularly re-check the state of Zendesk Triggers.
+const informerResyncPeriod = time.Minute * 5
 
 // NewController creates a Reconciler for the event source and returns the result of NewImpl.
 func NewController(
@@ -59,7 +63,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informerv1alpha1.Get(ctx).Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), informerResyncPeriod)
 
 	return impl
 }


### PR DESCRIPTION
When Zendesk denies an API request due to bad credentials (401 Unauthorized), and Knative retries API calls multiple times in a row, Zendesk eventually denies all subsequent API calls with `TooManyFailedLoginAttempts`, causing all other sources to fail as well.

```
Events:
  Type     Reason         Age                    From                      Message
  ----     ------         ----                   ----                      -------
  Warning  InternalError  26m (x5 over 77m)      zendesksource-controller  error retrieving Zendesk targets: Zendesk API returned error (401): {"error":"Couldn't authenticate you"}
  Warning  InternalError  3m4s (x12 over 3m48s)  zendesksource-controller  error retrieving Zendesk targets: Zendesk API returned error (403): {"error":"TooManyFailedLoginAttempts","description":"Too many failed login attempts in a short period of time, try again later."}
```

This PR ensures 401 errors are not retried until the next informer notification.