### PR TITLE
Find adapter by label and owner

### DIFF
--- a/pkg/reconciler/common/adapter.go
+++ b/pkg/reconciler/common/adapter.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"strings"
+
+	"knative.dev/pkg/kmeta"
+)
+
+// AdapterName returns the adapter's name for the given source object.
+func AdapterName(o kmeta.OwnerRefable) string {
+	return strings.ToLower(o.GetGroupVersionKind().Kind)
+}

--- a/pkg/reconciler/httpsource/adapter.go
+++ b/pkg/reconciler/httpsource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package httpsource
 
 import (
-	"fmt"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,8 +30,6 @@ import (
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "httpsource"
 
 const (
 	envHTTPEventType         = "HTTP_EVENT_TYPE"
@@ -56,8 +53,10 @@ type adapterConfig struct {
 // adapterServiceBuilder returns an AdapterServiceBuilderFunc for the
 // given source object and adapter config.
 func adapterServiceBuilder(src *v1alpha1.HTTPSource, cfg *adapterConfig) common.AdapterServiceBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *servingv1.Service {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/httpsource/controller.go
+++ b/pkg/reconciler/httpsource/controller.go
@@ -38,10 +38,13 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.HTTPSource)(nil)
+	app := common.AdapterName(typ)
+
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -50,7 +53,7 @@ func NewController(
 
 	r.base = common.NewGenericServiceReconciler(
 		ctx,
-		(&v1alpha1.HTTPSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/slacksource/adapter.go
+++ b/pkg/reconciler/slacksource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package slacksource
 
 import (
-	"fmt"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,8 +30,6 @@ import (
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "slacksource"
 
 const (
 	envSlackAppID         = "SLACK_APP_ID"
@@ -54,8 +51,10 @@ type adapterConfig struct {
 // adapterServiceBuilder returns an AdapterServiceBuilderFunc for the
 // given source object and adapter config.
 func adapterServiceBuilder(src *v1alpha1.SlackSource, cfg *adapterConfig) common.AdapterServiceBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *servingv1.Service {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/slacksource/controller.go
+++ b/pkg/reconciler/slacksource/controller.go
@@ -37,12 +37,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.SlackSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -51,7 +54,7 @@ func NewController(
 
 	r.base = common.NewGenericServiceReconciler(
 		ctx,
-		(&v1alpha1.SlackSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)

--- a/pkg/reconciler/zendesksource/adapter.go
+++ b/pkg/reconciler/zendesksource/adapter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package zendesksource
 
 import (
-	"fmt"
 	"strconv"
 
 	"knative.dev/eventing/pkg/reconciler/source"
@@ -29,8 +28,6 @@ import (
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common/resource"
 )
-
-const adapterName = "zendesksource"
 
 const (
 	envZdSubdomain   = "ZENDESK_SUBDOMAIN"
@@ -53,8 +50,10 @@ type adapterConfig struct {
 // adapterServiceBuilder returns an AdapterServiceBuilderFunc for the
 // given source object and adapter config.
 func adapterServiceBuilder(src *v1alpha1.ZendeskSource, cfg *adapterConfig) common.AdapterServiceBuilderFunc {
+	adapterName := common.AdapterName(src)
+
 	return func(sinkURI *apis.URL) *servingv1.Service {
-		name := kmeta.ChildName(fmt.Sprintf("%s-", adapterName), src.Name)
+		name := kmeta.ChildName(adapterName+"-", src.Name)
 
 		var sinkURIStr string
 		if sinkURI != nil {

--- a/pkg/reconciler/zendesksource/controller.go
+++ b/pkg/reconciler/zendesksource/controller.go
@@ -43,12 +43,15 @@ func NewController(
 	cmw configmap.Watcher,
 ) *controller.Impl {
 
+	typ := (*v1alpha1.ZendeskSource)(nil)
+	app := common.AdapterName(typ)
+
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.
 	adapterCfg := &adapterConfig{
-		configs: source.WatchConfigurations(ctx, adapterName, cmw, source.WithLogging, source.WithMetrics),
+		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),
 	}
-	envconfig.MustProcess(adapterName, adapterCfg)
+	envconfig.MustProcess(app, adapterCfg)
 
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
@@ -58,7 +61,7 @@ func NewController(
 
 	r.base = common.NewGenericServiceReconciler(
 		ctx,
-		(&v1alpha1.ZendeskSource{}).GetGroupVersionKind(),
+		typ.GetGroupVersionKind(),
 		impl.EnqueueKey,
 		impl.EnqueueControllerOf,
 	)


### PR DESCRIPTION
_identical changes to triggermesh/aws-event-sources#186_

Implements a method that finds the receive adapter for a given source by label and owner, instead of making assumptions on the adapter's name.

Closes #59