### PR TITLE
Implement ZendeskSource finalizer

### DIFF
--- a/pkg/reconciler/testing/reconcile.go
+++ b/pkg/reconciler/testing/reconcile.go
@@ -108,6 +108,7 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 		{
 			Name: "Source object deletion",
 			Key:  tKey,
+			Ctx:  skipCtx,
 			Objects: []runtime.Object{
 				newEventSource(deleted),
 			},
@@ -365,6 +366,9 @@ func unknownDeployedWithError(adapter runtime.Object) sourceOption {
 func deleted(src v1alpha1.EventSource) {
 	t := metav1.Unix(0, 0)
 	src.SetDeletionTimestamp(&t)
+	// ignore assertion of Finalizer in those tests because not all types
+	// implement it
+	src.SetFinalizers(nil)
 }
 
 /* Adapter */

--- a/pkg/reconciler/zendesksource/events.go
+++ b/pkg/reconciler/zendesksource/events.go
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2020 TriggerMesh, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zendesksource
+
+const (
+	// ReasonTargetDeleted indicates the successful deletion of a Zendesk Target/Trigger.
+	ReasonTargetDeleted = "TargetDeleted"
+	// ReasonFailedTargetDelete indicates a failure during the deletion of a Zendesk Target/Trigger.
+	ReasonFailedTargetDelete = "FailedTargetDelete"
+)

--- a/pkg/reconciler/zendesksource/reconciler.go
+++ b/pkg/reconciler/zendesksource/reconciler.go
@@ -38,6 +38,9 @@ type Reconciler struct {
 // Check that our Reconciler implements Interface
 var _ reconcilerv1alpha1.Interface = (*Reconciler)(nil)
 
+// Check that our Reconciler implements Finalizer
+var _ reconcilerv1alpha1.Finalizer = (*Reconciler)(nil)
+
 // ReconcileKind implements Interface.ReconcileKind.
 func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.ZendeskSource) reconciler.Event {
 	// inject source into context for usage in reconciliation logic
@@ -48,4 +51,15 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.ZendeskSou
 	}
 
 	return r.ensureZendeskTargetAndTrigger(ctx)
+}
+
+// FinalizeKind is called when the resource is deleted.
+func (r *Reconciler) FinalizeKind(ctx context.Context, src *v1alpha1.ZendeskSource) reconciler.Event {
+	// inject source into context for usage in finalization logic
+	ctx = v1alpha1.WithSource(ctx, src)
+
+	// The finalizer blocks the deletion of the source object until
+	// ensureNoZendeskTargetAndTrigger succeeds to ensure that we don't
+	// leave any dangling Zendesk Target/Trigger behind us.
+	return r.ensureNoZendeskTargetAndTrigger(ctx)
 }

--- a/pkg/reconciler/zendesksource/reconciler_test.go
+++ b/pkg/reconciler/zendesksource/reconciler_test.go
@@ -30,6 +30,7 @@ import (
 	"knative.dev/pkg/resolver"
 	fakeservinginjectionclient "knative.dev/serving/pkg/client/injection/client/fake"
 
+	"github.com/triggermesh/knative-sources/pkg/apis/sources"
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/knative-sources/pkg/client/generated/injection/client/fake"
 	reconcilerv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/zendesksource"
@@ -98,6 +99,10 @@ func newEventSource() *v1alpha1.ZendeskSource {
 			},
 		},
 	}
+
+	// assume finalizer is already set to prevent the generated reconciler
+	// from generating an extra Patch action
+	src.Finalizers = []string{sources.ZendeskSourceResource.String()}
 
 	Populate(src)
 

--- a/pkg/reconciler/zendesksource/zendesk.go
+++ b/pkg/reconciler/zendesksource/zendesk.go
@@ -95,7 +95,7 @@ func (r *Reconciler) ensureZendeskTargetAndTrigger(ctx context.Context) error {
 
 	case err != nil:
 		status.MarkTargetNotSynced(v1alpha1.ZendeskReasonFailedSync, "Unable to list Targets")
-		return fmt.Errorf("error retrieving Zendesk Targets: %w", err)
+		return fmt.Errorf("retrieving Zendesk Targets: %w", err)
 	}
 
 	var currentTarget *zendesk.Target
@@ -125,7 +125,7 @@ func (r *Reconciler) ensureZendeskTargetAndTrigger(ctx context.Context) error {
 			// but is in a different page. We will need to support
 			// pagination in a future release of this source.
 			status.MarkTargetNotSynced(v1alpha1.ZendeskReasonFailedSync, "Unable to create Target")
-			return fmt.Errorf("error creating Zendesk target: %w", err)
+			return fmt.Errorf("creating Zendesk Target: %w", err)
 		}
 		currentTarget = &resp
 	}
@@ -133,7 +133,7 @@ func (r *Reconciler) ensureZendeskTargetAndTrigger(ctx context.Context) error {
 	triggers, _, err := client.GetTriggers(ctx, &zendesk.TriggerListOptions{})
 	if err != nil {
 		status.MarkTargetNotSynced(v1alpha1.ZendeskReasonFailedSync, "Unable to list Triggers")
-		return fmt.Errorf("error retrieving Zendesk Triggers: %w", err)
+		return fmt.Errorf("retrieving Zendesk Triggers: %w", err)
 	}
 
 	var currentTrigger *zendesk.Trigger
@@ -165,7 +165,7 @@ func (r *Reconciler) ensureZendeskTargetAndTrigger(ctx context.Context) error {
 
 		if _, err := client.CreateTrigger(ctx, desiredTrigger); err != nil {
 			status.MarkTargetNotSynced(v1alpha1.ZendeskReasonFailedSync, "Unable to create Trigger")
-			return fmt.Errorf("error creating Zendesk target trigger: %w", err)
+			return fmt.Errorf("creating Zendesk Trigger: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Upon deletion of the ZendeskSource object, the finalizer attempts to delete the corresponding Zendesk Target+Trigger. Errors are retried by the Knative reconciler, unless the error is an authentication error, in which case we give up (unrecoverable).

Closes #38