### PR TITLE
Propagate status of dependant objects to Deployed condition

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -124,6 +124,14 @@ rules:
   - channels
   verbs: *listwatch
 
+# Determine the exact reason why Deployments fail
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+
 ---
 
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".

--- a/pkg/reconciler/common/base.go
+++ b/pkg/reconciler/common/base.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
 	"k8s.io/client-go/tools/cache"
 
@@ -40,7 +41,8 @@ type GenericDeploymentReconciler struct {
 	// URI resolver for sinks
 	SinkResolver *resolver.URIResolver
 	// API clients
-	Client func(namespace string) appsclientv1.DeploymentInterface
+	Client    func(namespace string) appsclientv1.DeploymentInterface
+	PodClient func(namespace string) coreclientv1.PodInterface
 	// objects listers
 	Lister func(namespace string) appslistersv1.DeploymentNamespaceLister
 }
@@ -67,6 +69,7 @@ func NewGenericDeploymentReconciler(ctx context.Context, gvk schema.GroupVersion
 	r := GenericDeploymentReconciler{
 		SinkResolver: resolver.NewURIResolver(ctx, resolverCallback),
 		Client:       k8sclient.Get(ctx).AppsV1().Deployments,
+		PodClient:    k8sclient.Get(ctx).CoreV1().Pods,
 		Lister:       informer.Lister().Deployments,
 	}
 

--- a/pkg/reconciler/common/reconcile.go
+++ b/pkg/reconciler/common/reconcile.go
@@ -86,7 +86,7 @@ func (r *GenericDeploymentReconciler) reconcileAdapter(ctx context.Context, desi
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
-		src.GetSourceStatus().PropagateAvailability(currentAdapter)
+		src.GetSourceStatus().PropagateDeploymentAvailability(ctx, currentAdapter, r.PodClient(src.GetNamespace()))
 		return err
 	}
 
@@ -94,7 +94,7 @@ func (r *GenericDeploymentReconciler) reconcileAdapter(ctx context.Context, desi
 	if err != nil {
 		return fmt.Errorf("failed to synchronize adapter Deployment: %w", err)
 	}
-	src.GetSourceStatus().PropagateAvailability(currentAdapter)
+	src.GetSourceStatus().PropagateDeploymentAvailability(ctx, currentAdapter, r.PodClient(src.GetNamespace()))
 
 	return nil
 }

--- a/pkg/reconciler/common/reconcile.go
+++ b/pkg/reconciler/common/reconcile.go
@@ -197,7 +197,7 @@ func (r *GenericServiceReconciler) reconcileAdapter(ctx context.Context, desired
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
-		src.GetSourceStatus().PropagateAvailability(currentAdapter)
+		src.GetSourceStatus().PropagateServiceAvailability(currentAdapter)
 		return err
 	}
 
@@ -205,7 +205,7 @@ func (r *GenericServiceReconciler) reconcileAdapter(ctx context.Context, desired
 	if err != nil {
 		return fmt.Errorf("failed to synchronize adapter Service: %w", err)
 	}
-	src.GetSourceStatus().PropagateAvailability(currentAdapter)
+	src.GetSourceStatus().PropagateServiceAvailability(currentAdapter)
 
 	return nil
 }

--- a/pkg/reconciler/testing/reconcile.go
+++ b/pkg/reconciler/testing/reconcile.go
@@ -362,7 +362,7 @@ func propagateAdapterAvailabilityFunc(adapter runtime.Object) func(src v1alpha1.
 		case *appsv1.Deployment:
 			src.GetSourceStatus().PropagateDeploymentAvailability(context.Background(), a, nil)
 		case *servingv1.Service:
-			src.GetSourceStatus().PropagateAvailability(a)
+			src.GetSourceStatus().PropagateServiceAvailability(a)
 		}
 	}
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -18,10 +18,26 @@ limitations under the License.
 package status
 
 import (
+	"strings"
+	"unicode"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"knative.dev/pkg/apis"
+)
+
+const (
+	ReasonAppRuntimeFailure = "AppRuntimeFailure"
+	ReasonBadContainerImage = "BadContainerImage"
+
+	reasonMissingPrefix = "Missing"
+
+	// https://github.com/knative/serving/blob/release-0.16/pkg/apis/serving/v1/configuration_lifecycle.go#L91
+	knRevisionFailedReason = "RevisionFailed"
 )
 
 // DeploymentPodsWaitingState collects the Pods owned by the given Deployment
@@ -49,3 +65,177 @@ func DeploymentPodsWaitingState(d *appsv1.Deployment,
 
 	return nil, nil
 }
+
+// ExactReason tries to determine the exact reason of a failure from a
+// container state or Knative status condition. The format of the returned
+// reason follows the CamelCased one-word convention described at
+// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+// When a more specific reason can not be determined, the original reason is
+// returned.
+func ExactReason(state interface{}) string /*reason*/ {
+	switch in := state.(type) {
+	case *corev1.ContainerStateWaiting:
+		return exactReason(in.Reason, in.Message)
+	case *apis.Condition:
+		return exactReason(in.Reason, in.Message)
+	}
+	return ""
+}
+
+func exactReason(reason, msg string) string /*reason*/ {
+	if isRuntimeError(reason, msg) {
+		return ReasonAppRuntimeFailure
+	}
+
+	if isBadImageError(reason, msg) {
+		return ReasonBadContainerImage
+	}
+
+	if missing, typ := isResourceMissingError(reason, msg); missing {
+		return reasonMissingPrefix + typ
+	}
+
+	return reason
+}
+
+// isRuntimeError returns whether the given combination of reason and message
+// indicates that a container within a Pod is failing to run.
+func isRuntimeError(reason, msg string) bool {
+	// https://github.com/knative/serving/blob/release-0.16/pkg/apis/serving/v1/revision_lifecycle.go#L203
+	const knContainerFailurePrefix = "Container failed with: "
+
+	return runtimeErrorReasons.Has(reason) ||
+		reason == knRevisionFailedReason && strings.Contains(msg, knContainerFailurePrefix)
+}
+
+// isBadImageError returns whether the given combination of reason and message
+// indicates that a container image can not be pulled.
+func isBadImageError(reason, msg string) bool {
+	// https://github.com/knative/serving/blob/release-0.16/pkg/apis/serving/v1/revision_lifecycle.go#L209
+	const knFetchImgErrorPrefix = `Unable to fetch image "`
+
+	return imagePullErrorReasons.Has(reason) ||
+		// Knative Serving uses its own image resolver to determine whether an
+		// image can be pulled, therefore the message indicating a failure can
+		// be considered stable.
+		// https://github.com/knative/serving/blob/release-0.16/pkg/reconciler/revision/revision.go#L122
+		reason == knRevisionFailedReason && strings.Contains(msg, knFetchImgErrorPrefix)
+}
+
+// isResourceMissingError returns whether the given combination of reason and
+// message indicates that a resource is missing. If that's the case, the type
+// of the resource is also returned.
+// This parsing logic is tailored to the error message to avoid the use of
+// regular expressions.
+// The expected format comes from the standard Kubernetes API errors:
+// https://github.com/kubernetes/kubernetes/blob/release-1.18/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go#L139
+func isResourceMissingError(reason, msg string) (bool, string /*resource type*/) {
+	const quoteNotFound = `" not found`
+
+	// https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+	const maxK8sNameLength = 253
+
+	if !resourceMissingErrorReasons.Has(reason) {
+		return false, ""
+	}
+
+	msg = strings.TrimSuffix(msg, ".")
+	if !strings.HasSuffix(msg, quoteNotFound) {
+		return false, ""
+	}
+
+	// We know the message is likely to have the expected format based on
+	// its suffix, so we try to extract the resource type:
+	//
+	//   `failed to do xyz: secret "my-api-token" not found`
+	//                      ^^^^^^
+	//
+	// To do so, we first ensure the message includes an opening quote:
+	//
+	//   `failed to do xyz: secret "my-api-token" not found`
+	//                             ^
+	//
+	// If that is the case, we parse the string in reverse from the
+	// position of that quote until the beginning of a word:
+	//
+	//   `failed to do xyz: secret "my-api-token" not found`
+	//                      |<-----^
+
+	// index of the closing and opening quote chars
+	closingResNameQuoteIdx := len(msg) - len(quoteNotFound)
+	openingResNameQuoteIdx := strings.LastIndex(msg[:closingResNameQuoteIdx], `"`)
+
+	// we couldn't find the opening quote or it's at the beginning of the message
+	if openingResNameQuoteIdx <= 0 ||
+		// the quoted string exceeds the maximum length of a Kubernetes object
+		(closingResNameQuoteIdx-openingResNameQuoteIdx)+1 > maxK8sNameLength ||
+		// the preceding char is not a space
+		msg[openingResNameQuoteIdx-1] != ' ' {
+
+		return false, ""
+	}
+
+	// parse the type in reverse starting from before the opening quote
+	typeBeginningIdx := openingResNameQuoteIdx - 1
+	for i := openingResNameQuoteIdx - 1; i > 0; i-- {
+		if unicode.IsLetter(rune(msg[i-1])) {
+			// if we reached the beginning of the message, it means
+			// the type is at the beginning of the message
+			if i-1 == 0 {
+				typeBeginningIdx = 0
+			}
+			continue
+		}
+		// break on the first occurence of a non-letter char
+		typeBeginningIdx = i
+		break
+	}
+	// edge case: the resource name is empty
+	if (openingResNameQuoteIdx-1)-typeBeginningIdx == 0 {
+		return false, ""
+	}
+
+	var typ strings.Builder
+	for i, char := range msg[typeBeginningIdx:(openingResNameQuoteIdx - 1)] {
+		if i == 0 {
+			typ.WriteRune(unicode.ToUpper(char))
+			continue
+		}
+		typ.WriteRune(char)
+	}
+
+	return true, typ.String()
+}
+
+// runtimeErrorReasons is a set of status reasons that could indicate that a
+// container is failing to run.
+// https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/kubelet/container/sync_result.go#L29-L45
+var runtimeErrorReasons = sets.NewString(
+	"CrashLoopBackOff",
+	"RunContainerError",
+	"RunInitContainerError",
+	"CreatePodSandboxError",
+	"ConfigPodSandboxError",
+	"VerifyNonRootError",
+)
+
+// imagePullErrorReasons is a set of status reasons that could indicate that a
+// container image can not be pulled.
+// https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/kubelet/images/types.go#L26-L44
+var imagePullErrorReasons = sets.NewString(
+	"ImagePullBackOff",
+	"ImageInspectError",
+	"ErrImagePull",
+	"ErrImageNeverPull",
+	"RegistryUnavailable",
+	"InvalidImageName",
+)
+
+// resourceMissingErrorReasons is a set of status reasons that could indicate that a
+// container is missing required resources.
+// https://github.com/kubernetes/kubernetes/blob/release-1.17/pkg/kubelet/kuberuntime/kuberuntime_container.go#L55-L58
+var resourceMissingErrorReasons = sets.NewString(
+	"CreateContainerConfigError",
+	"CreateContainerError",
+	knRevisionFailedReason,
+)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,51 @@
+/*
+Copyright (c) 2020 TriggerMesh, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package status contains helpers to observe the status of Kubernetes objects.
+package status
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// DeploymentPodsWaitingState collects the Pods owned by the given Deployment
+// and returns the state of the first observed Pod in a "waiting" state, or nil
+// if no Pod is found in that state.
+func DeploymentPodsWaitingState(d *appsv1.Deployment,
+	pi coreclientv1.PodInterface) (*corev1.ContainerStateWaiting, error) {
+
+	pods, err := pi.List(metav1.ListOptions{LabelSelector: d.Spec.Selector.String()})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, p := range pods.Items {
+		if p.Status.Phase == corev1.PodRunning || p.Status.Phase == corev1.PodSucceeded {
+			continue
+		}
+
+		for _, ps := range p.Status.ContainerStatuses {
+			if ws := ps.State.Waiting; ws != nil {
+				return ws, nil
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright (c) 2020 TriggerMesh, Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+)
+
+func TestExactReason(t *testing.T) {
+	const fakeReason = "FakeReason"
+
+	containerTestCases := []struct {
+		name         string
+		input        *corev1.ContainerStateWaiting
+		expectReason string
+	}{
+		{
+			name: "Generic error condition",
+			input: &corev1.ContainerStateWaiting{
+				Reason:  fakeReason,
+				Message: "Some error message",
+			},
+			expectReason: fakeReason,
+		},
+		{
+			name: "Container image error",
+			input: &corev1.ContainerStateWaiting{
+				Reason:  "ImagePullBackOff",
+				Message: "Some error message",
+			},
+			expectReason: ReasonBadContainerImage,
+		},
+		{
+			name: "Runtime error",
+			input: &corev1.ContainerStateWaiting{
+				Reason:  "CrashLoopBackOff",
+				Message: "Some error message",
+			},
+			expectReason: ReasonAppRuntimeFailure,
+		},
+		{
+			name: "Missing resource error",
+			input: &corev1.ContainerStateWaiting{
+				Reason:  "CreateContainerConfigError",
+				Message: `foo "xyz" not found`,
+			},
+			expectReason: "MissingFoo",
+		},
+		{
+			name: "Missing resource error with wrong reason",
+			input: &corev1.ContainerStateWaiting{
+				Reason:  fakeReason,
+				Message: `foo "xyz" not found`,
+			},
+			expectReason: fakeReason,
+		},
+	}
+
+	knativeTestCases := []struct {
+		name         string
+		input        *apis.Condition
+		expectReason string
+	}{
+		{
+			name: "Generic error condition",
+			input: &apis.Condition{
+				Reason:  fakeReason,
+				Message: "Some error message",
+			},
+			expectReason: fakeReason,
+		},
+		{
+			name: "Runtime error",
+			input: &apis.Condition{
+				Reason:  knRevisionFailedReason,
+				Message: "Some error message: Container failed with: oops",
+			},
+			expectReason: ReasonAppRuntimeFailure,
+		},
+		{
+			name: "Runtime error with wrong reason",
+			input: &apis.Condition{
+				Reason:  fakeReason,
+				Message: "Some error message: Container failed with: oops",
+			},
+			expectReason: fakeReason,
+		},
+		{
+			name: "Container image error",
+			input: &apis.Condition{
+				Reason:  knRevisionFailedReason,
+				Message: `Unable to fetch image "foo": some error`,
+			},
+			expectReason: ReasonBadContainerImage,
+		},
+		{
+			name: "Container image error with wrong reason",
+			input: &apis.Condition{
+				Reason:  fakeReason,
+				Message: `Unable to fetch image "foo": some error`,
+			},
+			expectReason: fakeReason,
+		},
+		{
+			name: "Missing resource error",
+			input: &apis.Condition{
+				Reason:  knRevisionFailedReason,
+				Message: `foo "xyz" not found`,
+			},
+			expectReason: "MissingFoo",
+		},
+		{
+			name: "Missing resource error with wrong reason",
+			input: &apis.Condition{
+				Reason:  fakeReason,
+				Message: `foo "xyz" not found`,
+			},
+			expectReason: fakeReason,
+		},
+	}
+
+	t.Run("Container", func(t *testing.T) {
+		for _, tc := range containerTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				reason := ExactReason(tc.input)
+				require.Equal(t, tc.expectReason, reason)
+			})
+		}
+	})
+
+	t.Run("Knative", func(t *testing.T) {
+		for _, tc := range knativeTestCases {
+			t.Run(tc.name, func(t *testing.T) {
+				reason := ExactReason(tc.input)
+				require.Equal(t, tc.expectReason, reason)
+			})
+		}
+	})
+}
+
+func TestIsResourceMissingError(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         string
+		expectMissing bool
+		expectType    string
+	}{
+		{
+			name:          "Matching input format",
+			input:         `failed to do xyz: secret "my-api-token" not found`,
+			expectMissing: true,
+			expectType:    "Secret",
+		},
+		{
+			name:          "Matching input format without error decoration",
+			input:         `secret "my-api-token" not found`,
+			expectMissing: true,
+			expectType:    "Secret",
+		},
+		{
+			name:          "Matching input format with single trailing period",
+			input:         `failed to do xyz: secret "my-api-token" not found.`,
+			expectMissing: true,
+			expectType:    "Secret",
+		},
+		{
+			name:          "Non-matching input format",
+			input:         `failed to do xyz: something "my-api-token" something`,
+			expectMissing: false,
+		},
+		{
+			name:          "No opening quote",
+			input:         `failed to do xyz: secret my-api-token" not found`,
+			expectMissing: false,
+		},
+		{
+			name:          "No resource type",
+			input:         `failed to do xyz: "my-api-token" not found`,
+			expectMissing: false,
+		},
+		{
+			name:          "Input starts with a quote",
+			input:         `"my-api-token" not found`,
+			expectMissing: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			missing, typ := isResourceMissingError(knRevisionFailedReason, tc.input)
+			require.Equal(t, tc.expectMissing, missing, "Message describes a missing resource")
+			require.Equal(t, tc.expectType, typ)
+		})
+	}
+}


### PR DESCRIPTION
Taking a stab at #73.

The reason why underlying Pods are failing is now included in the message of status conditions.

A few examples I observed while testing with a Ksvc-based event source (Zendesk):

1. The adapter is still deploying

```yaml
    conditions:
    - lastTransitionTime: "2020-08-13T00:47:35Z"
      message: The adapter Service is unavailable; Revision "zendesksource-zendesksource-lj7kl"
        referenced in traffic not found.; The Configuration is still working to reflect
        the latest desired specification.
      reason: AdapterUnavailable
      status: "False"
      type: Deployed
```

2. A Secret is missing

```yaml
    conditions:
    - lastTransitionTime: "2020-08-13T00:49:37Z"
      message: 'The adapter Service is unavailable; Revision "zendesksource-zendesksource-lj7kl"
        referenced in traffic not found.; Revision "zendesksource-zendesksource-zpj6g"
        failed with message: secret "zendesksource" not found.'
      reason: MissingSecret
      status: "False"
      type: Deployed
```

3. The adapter's image cannot be found

```yaml
    conditions:
    - lastTransitionTime: "2020-08-13T00:46:36Z"
      message: 'The adapter Service is unavailable; Revision "zendesksource-zendesksource-lj7kl"
        referenced in traffic not found.; Revision "zendesksource-zendesksource-6srdp"
        failed with message: Unable to fetch image "gcr.io/triggermesh/zendesksource-adapter:4c8a60adcd2f37d965ee3b45410fa2d5051226bax": [...]'
      reason: BadContainerImage
      status: "False"
      type: Deployed
```

The examples above work equally well with Deployments, the message is slightly different but the error reason is the same.

Closes #73 