### PR TITLE
Fix blocked Zendesk finalizer despite unrecoverable error

### DIFF
--- a/pkg/reconciler/zendesksource/zendesk.go
+++ b/pkg/reconciler/zendesksource/zendesk.go
@@ -206,8 +206,9 @@ func (r *Reconciler) ensureNoZendeskTargetAndTrigger(ctx context.Context) error 
 		// it is unlikely that we recover from auth errors in the
 		// finalizer, so we simply record a warning event and return to
 		// allow the reconciler to remove the finalizer
-		return reconciler.NewEvent(corev1.EventTypeWarning, ReasonFailedTargetDelete,
-			"Authorization error finalizing Zendesk Target %q. Ignoring: %s", title, err)
+		event.Warn(ctx, ReasonFailedTargetDelete, "Authorization error finalizing Zendesk Target %q. "+
+			"Ignoring: %s", title, err)
+		return nil
 
 	case err != nil:
 		// wrap any other error to fail the finalization


### PR DESCRIPTION
Knative records the event _without removing the finalizer_ if the event is of type Warning: https://github.com/knative/pkg/blob/3a98b067/codegen/cmd/injection-gen/generators/reconciler_reconciler.go#L636-L638

To send a warning event without blocking the finalizer, we need to send it ourselves and return `nil`.

Closes #79