### PR TITLE
Ensure CE extension follows attribute naming convention

### DIFF
--- a/pkg/adapter/slacksource/slack.go
+++ b/pkg/adapter/slacksource/slack.go
@@ -31,6 +31,8 @@ import (
 	"go.uber.org/zap"
 )
 
+const apiAppIdCeExtension = "comslackapiappid"
+
 // SlackEventAPIHandler listen for Slack API Events
 type SlackEventAPIHandler interface {
 	Start(ctx context.Context) error
@@ -207,7 +209,7 @@ func cloudEventFromEventWrapper(wrapper *SlackEventWrapper) (*cloudevents.Event,
 	event.SetID(wrapper.EventID)
 	event.SetType(v1alpha1.SlackGenericEventType)
 	event.SetSource(wrapper.TeamID)
-	event.SetExtension("api_app_id", wrapper.APIAppID)
+	event.SetExtension(apiAppIdCeExtension, wrapper.APIAppID)
 	event.SetTime(time.Unix(int64(wrapper.EventTime), 0))
 	event.SetSubject(wrapper.Event.Type())
 	if err := event.SetData(cloudevents.ApplicationJSON, wrapper.Event); err != nil {

--- a/pkg/adapter/slacksource/slack_test.go
+++ b/pkg/adapter/slacksource/slack_test.go
@@ -14,10 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// import (
-// 	cloudevents "github.com/cloudevents/sdk-go/v2"
-// )
-
 package slacksource
 
 import (


### PR DESCRIPTION
Fixes #84

The Slack source is failing because the CloudEvents SDK became more strict about validating CE attributes. Unfortunately, that means `api_app_id` is now rejected, as per the [Attribute Naming Convention](https://github.com/cloudevents/spec/blob/master/spec.md#attribute-naming-convention).