### PR TITLE
Use addressable-resolver Role instead of an explicit list of resources

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -88,7 +88,7 @@ rules:
   - ''
   resources:
   - configmaps
-  verbs: &listwatch
+  verbs:
   - list
   - watch
 - apiGroups:
@@ -120,28 +120,6 @@ rules:
   verbs:
   - get
   - update
-
-# Resolve sink URIs
-- apiGroups:
-  - ''
-  resources:
-  - services
-  verbs: *listwatch
-- apiGroups:
-  - serving.knative.dev
-  resources:
-  - services
-  verbs: *listwatch
-- apiGroups:
-  - eventing.knative.dev
-  resources:
-  - brokers
-  verbs: *listwatch
-- apiGroups:
-  - messaging.knative.dev
-  resources:
-  - channels
-  verbs: *listwatch
 
 # Determine the exact reason why Deployments fail
 - apiGroups:

--- a/config/201-serviceaccounts.yaml
+++ b/config/201-serviceaccounts.yaml
@@ -32,3 +32,19 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: *app
+
+---
+
+# Resolve sink URIs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-sources-controller-addressable-resolver
+subjects:
+- kind: ServiceAccount
+  name: knative-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: addressable-resolver


### PR DESCRIPTION
We don't need to enumerate every possible addressable type in our ClusterRole because Knative already aggregates these in an `addressable-resolver` ClusterRole.

https://github.com/knative/eventing/blob/release-0.17/docs/spec/channel.md#aggregated-addressable-resolver-clusterrole