### PR TITLE
Replace pod/get RBAC permission with pod/list

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -127,7 +127,7 @@ rules:
   resources:
   - pods
   verbs:
-  - get
+  - list
 
 ---
 


### PR DESCRIPTION
Here is the code that requires that permission:

https://github.com/triggermesh/knative-sources/blob/8832226b982025ef91e0a583c1c5c63a4af3c345/pkg/status/status.go#L50-L52