### PR TITLE
Add JSON schemas for emitted event types

### DIFF
--- a/pkg/adapter/zendesksource/zendesk.go
+++ b/pkg/adapter/zendesksource/zendesk.go
@@ -202,21 +202,17 @@ func (h *zendeskAPIHandler) handleError(err error, w http.ResponseWriter) {
 }
 
 func (h *zendeskAPIHandler) cloudEventFromWrapper(ze *ZendeskEvent) (*cloudevents.Event, error) {
-	data, err := json.Marshal(ze)
-	if err != nil {
-		return nil, err
-	}
 	event := cloudevents.NewEvent(cloudevents.VersionV1)
 
 	if ticketType := ze.Type(); ticketType != "" {
-		event.SetExtension("ticket_type", ticketType)
+		event.SetExtension("tickettype", ticketType)
 	}
 	event.SetID(ze.ID())
 	event.SetType(v1alpha1.ZendeskTicketCreatedEventType)
 	event.SetSource(h.eventsource)
 	event.SetSubject(ze.Title())
 
-	if err := event.SetData(cloudevents.ApplicationJSON, data); err != nil {
+	if err := event.SetData(cloudevents.ApplicationJSON, ze); err != nil {
 		return nil, fmt.Errorf("failed to set event data: %w", err)
 	}
 

--- a/schemas/com.slack.events.json
+++ b/schemas/com.slack.events.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Standard event wrapper for the Events API",
+  "description": "Adapted from auto-generated content",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "token",
+    "team_id",
+    "api_app_id",
+    "event",
+    "type",
+    "event_id",
+    "event_time",
+    "authed_users"
+  ],
+  "properties": {
+    "token": {
+      "title": "A verification token to validate the event originated from Slack",
+      "type": "string"
+    },
+    "team_id": {
+      "title": "The unique identifier of the workspace where the event occurred",
+      "type": "string",
+      "examples": [
+        "T1H9RESGL"
+      ]
+    },
+    "api_app_id": {
+      "title": "The unique identifier your installed Slack application.",
+      "description": " Use this to distinguish which app the event belongs to if you use multiple apps with the same Request URL.",
+      "type": "string",
+      "examples": [
+        "A2H9RFS1A"
+      ]
+    },
+    "event": {
+      "title": "The actual event, an object, that happened. You'll find the most variance in properties beneath this node.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "type",
+        "event_ts"
+      ],
+      "properties": {
+        "type": {
+          "title": "The specific name of the event",
+          "type": "string"
+        },
+        "event_ts": {
+          "title": "When the event was dispatched",
+          "type": "string"
+        }
+      },
+      "examples": [
+        {
+          "type": "message",
+          "user": "U061F7AUR",
+          "text": "How many cats did we herd yesterday?",
+          "ts": "1525215129.000001",
+          "channel": "D0PNCRP9N",
+          "event_ts": "1525215129.000001",
+          "channel_type": "app_home"
+        }
+      ]
+    },
+    "type": {
+      "title": "Indicates which kind of event dispatch this is, usually `event_callback`",
+      "type": "string",
+      "examples": [
+        "event_callback"
+      ]
+    },
+    "event_id": {
+      "title": "A unique identifier for this specific event, globally unique across all workspaces.",
+      "type": "string",
+      "examples": [
+        "Ev0PV52K25"
+      ]
+    },
+    "event_time": {
+      "title": "The epoch timestamp in seconds indicating when this event was dispatched.",
+      "type": "integer",
+      "examples": [
+        1525215129
+      ]
+    },
+    "authed_users": {
+      "title": "An array of string-based User IDs. Each member of the collection represents a user that has installed your application/bot and indicates the described event would be visible to those users.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "examples": [
+    {
+      "token": "XXYYZZ",
+      "team_id": "TXXXXXXXX",
+      "api_app_id": "AXXXXXXXXX",
+      "event": {
+        "type": "resources_added",
+        "resources": [
+          {
+            "resource": {
+              "type": "im",
+              "grant": {
+                "type": "specific",
+                "resource_id": "DXXXXXXXX"
+              }
+            },
+            "scopes": [
+              "chat:write:user",
+              "im:read",
+              "im:history",
+              "commands"
+            ]
+          }
+        ]
+      },
+      "type": "event_callback",
+      "authed_teams": [],
+      "event_id": "EvXXXXXXXX",
+      "event_time": 1234567890
+    },
+    {
+      "token": "XXYYZZ",
+      "team_id": "TXXXXXXXX",
+      "api_app_id": "AXXXXXXXXX",
+      "event": {
+        "type": "reaction_added",
+        "user": "U024BE7LH",
+        "reaction": "thumbsup",
+        "item_user": "U0G9QF9C6",
+        "item": {
+          "type": "message",
+          "channel": "C0G9QF9GZ",
+          "ts": "1360782400.498405"
+        },
+        "event_ts": "1360782804.083113"
+      },
+      "type": "event_callback",
+      "authed_teams": [],
+      "event_id": "EvXXXXXXXX",
+      "event_time": 1234567890
+    }
+  ]
+}

--- a/schemas/com.zendesk.ticket.created.json
+++ b/schemas/com.zendesk.ticket.created.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "ticket": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "external_id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        },
+        "via": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "priority": {
+          "type": "string"
+        },
+        "ticket_type": {
+          "type": "string"
+        },
+        "group_name": {
+          "type": "string"
+        },
+        "brand_name": {
+          "type": "string"
+        },
+        "due_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "account": {
+          "type": "string"
+        },
+        "assignee": {
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "name": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          }
+        },
+        "requester": {
+          "name": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "external_id": {
+            "type": "string"
+          },
+          "field": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string"
+          }
+        },
+        "organization": {
+          "name": {
+            "type": "string"
+          },
+          "external_id": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          }
+        },
+        "ccs": {
+          "type": "string"
+        },
+        "cc_names": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "string"
+        },
+        "current_holiday_name": {
+          "type": "string"
+        },
+        "ticket_field_id": {
+          "type": "string"
+        },
+        "ticket_field_option_title_id": {
+          "type": "string"
+        }
+      }
+    },
+    "current_user": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "first_name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "organization": {
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "details": {
+            "type": "string"
+          }
+        },
+        "external_id": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "details": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "language": {
+          "type": "string"
+        }
+      }
+    },
+    "satisfaction": {
+      "type": "object",
+      "properties": {
+        "current_rating": {
+          "type": "string"
+        },
+        "current_comment": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The schema for Slack events was copied from https://api.slack.com/types/event#json_schema.

The schema for the Zendesk source was written manually using [`our trigger template`](https://github.com/triggermesh/knative-sources/blob/f436a9ea8c1b6dbfac96d57d622f73892af52b82/pkg/reconciler/zendesksource/zendesk.go#L419-L483) as a reference.