### PR TITLE
http source: Refactor HTTP handler lifecycle code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ replace (
 require (
 	github.com/cloudevents/sdk-go/v2 v2.2.0
 	github.com/google/go-cmp v0.5.2
-	github.com/google/uuid v1.1.2
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/nukosuke/go-zendesk v0.7.7
 	github.com/stretchr/testify v1.6.1

--- a/pkg/adapter/httpsource/http_test.go
+++ b/pkg/adapter/httpsource/http_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go/v2"
 	cloudeventst "github.com/cloudevents/sdk-go/v2/client/test"
 	"github.com/stretchr/testify/assert"
 	zapt "go.uber.org/zap/zaptest"
@@ -114,7 +115,9 @@ func TestHTTPEvent(t *testing.T) {
 
 	for name, c := range tc {
 		t.Run(name, func(t *testing.T) {
-			ceClient, chEvent := cloudeventst.NewMockSenderClient(t, 1)
+			ceClient, chEvent := cloudeventst.NewMockSenderClient(t, 1,
+				cloudevents.WithTimeNow(), cloudevents.WithUUIDs(),
+			)
 
 			handler := &httpHandler{
 				eventType:   tEventType,


### PR DESCRIPTION
Small suggestion to simplify the code of the HTTP handler by moving the server lifecycle logic to a single `runHandler()` function:

* Control the runtime of the HTTP server using a single `Context` instead of a `gracefulShutdown()` function with multiple channels (either way, a single channel would have been enough).
* Remove `srv` from the `httpHandler` struct, it isn't accessed by anything.
* Remove explicit call to `uuid.New()`. The client passed by Knative does it for us.
* Fix a bug where `/health` was attached to the wrong `http.Mux`.