### PR TITLE
Multi-tenancy: Reconcile ServiceAccount per namespace and per source kind

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -75,6 +75,41 @@ rules:
   verbs:
   - patch
 
+# Manage resource-specific ServiceAccounts and RoleBindings
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - list
+  - watch
+  - create
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  resourceNames: &rbac-objects
+  - slacksource-adapter
+  - zendesksource-adapter
+  - httpsource-adapter
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - watch
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  resourceNames: *rbac-objects
+  verbs:
+  - update
+
 # Read credentials
 - apiGroups:
   - ''

--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -163,6 +163,30 @@ rules:
   - pods
   verbs:
   - list
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: slacksource-adapter
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: zendesksource-adapter
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: httpsource-adapter
+rules: []
 
 ---
 

--- a/pkg/apis/sources/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/common_lifecycle.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,6 +32,12 @@ import (
 
 	"github.com/triggermesh/knative-sources/pkg/status"
 )
+
+// EventType returns an event type in a format suitable for usage as a
+// CloudEvent type attribute.
+func EventType(service, eventType string) string {
+	return "io.triggermesh." + service + "." + eventType
+}
 
 // eventSourceConditionSet is a generic set of status conditions used by
 // default in all event sources.
@@ -77,6 +83,13 @@ func (m *EventSourceStatusManager) MarkNoSink() {
 	m.SinkURI = nil
 	m.ConditionSet.Manage(m).MarkFalse(ConditionSinkProvided,
 		ReasonSinkNotFound, "The sink does not exist or its URI is not set")
+}
+
+// MarkRBACNotBound sets the Deployed condition to False, indicating that the
+// adapter's ServiceAccount couldn't be bound.
+func (m *EventSourceStatusManager) MarkRBACNotBound() {
+	m.ConditionSet.Manage(m).MarkFalse(ConditionDeployed,
+		ReasonRBACNotBound, "The adapter's ServiceAccount can not be bound")
 }
 
 // PropagateDeploymentAvailability uses the readiness of the provided

--- a/pkg/apis/sources/v1alpha1/conditions.go
+++ b/pkg/apis/sources/v1alpha1/conditions.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -35,6 +35,9 @@ const (
 	// ReasonSinkEmpty is set on a SinkProvided condition when a sink URI is empty.
 	ReasonSinkEmpty = "EmptySinkURI"
 
+	// ReasonRBACNotBound is set on a Deployed condition when an adapter's
+	// ServiceAccount cannot be bound.
+	ReasonRBACNotBound = "RBACNotBound"
 	// ReasonUnavailable is set on a Deployed condition when an adapter in unavailable.
 	ReasonUnavailable = "AdapterUnavailable"
 )

--- a/pkg/reconciler/common/adapter.go
+++ b/pkg/reconciler/common/adapter.go
@@ -22,9 +22,13 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
@@ -34,17 +38,16 @@ import (
 const metricsPrometheusPort uint16 = 9092
 
 // AdapterName returns the adapter's name for the given source object.
-func AdapterName(o kmeta.OwnerRefable) string {
-	return strings.ToLower(o.GetGroupVersionKind().Kind)
+func AdapterName(src kmeta.OwnerRefable) string {
+	return strings.ToLower(src.GetGroupVersionKind().Kind)
 }
 
 // NewAdapterDeployment is a wrapper around resource.NewDeployment which
 // pre-populates attributes common to all adapter Deployments.
-func NewAdapterDeployment(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...resource.ObjectOption) *appsv1.Deployment {
+func NewAdapterDeployment(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...resource.ObjectOption) *appsv1.Deployment {
 	app := AdapterName(src)
-	meta := src.GetObjectMeta()
-	srcNs := meta.GetNamespace()
-	srcName := meta.GetName()
+	srcNs := src.GetNamespace()
+	srcName := src.GetName()
 
 	var sinkURIStr string
 	if sinkURI != nil {
@@ -68,8 +71,8 @@ func NewAdapterDeployment(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...res
 			resource.PodLabel(appPartOfLabel, partOf),
 			resource.PodLabel(appManagedByLabel, managedBy),
 
-			resource.EnvVar(envNamespace, srcNs),
-			resource.EnvVar(envName, srcName),
+			resource.ServiceAccount(AdapterRBACObjectsName(src)),
+
 			resource.EnvVar(envSink, sinkURIStr),
 		}, opts...)...,
 	)
@@ -77,11 +80,10 @@ func NewAdapterDeployment(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...res
 
 // NewAdapterKnService is a wrapper around resource.NewKnService which
 // pre-populates attributes common to all adapter Knative Services.
-func NewAdapterKnService(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...resource.ObjectOption) *servingv1.Service {
+func NewAdapterKnService(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...resource.ObjectOption) *servingv1.Service {
 	app := AdapterName(src)
-	meta := src.GetObjectMeta()
-	srcNs := meta.GetNamespace()
-	srcName := meta.GetName()
+	srcNs := src.GetNamespace()
+	srcName := src.GetName()
 
 	var sinkURIStr string
 	if sinkURI != nil {
@@ -104,12 +106,80 @@ func NewAdapterKnService(src kmeta.OwnerRefable, sinkURI *apis.URL, opts ...reso
 			resource.PodLabel(appPartOfLabel, partOf),
 			resource.PodLabel(appManagedByLabel, managedBy),
 
-			resource.EnvVar(envNamespace, srcNs),
-			resource.EnvVar(envName, srcName),
+			resource.ServiceAccount(AdapterRBACObjectsName(src)),
+
 			resource.EnvVar(envSink, sinkURIStr),
 			resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPort), 10)),
 		}, opts...)...,
 	)
+}
+
+// newServiceAccount returns a ServiceAccount object with its OwnerReferences
+// metadata attribute populated from the given owners.
+func newServiceAccount(src v1alpha1.EventSource, owners []kmeta.OwnerRefable) *corev1.ServiceAccount {
+	ownerRefs := make([]metav1.OwnerReference, len(owners))
+	for i, owner := range owners {
+		ownerRefs[i] = *kmeta.NewControllerRef(owner)
+		ownerRefs[i].Controller = ptr.Bool(false)
+	}
+
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       src.GetNamespace(),
+			Name:            AdapterRBACObjectsName(src),
+			OwnerReferences: ownerRefs,
+			Labels:          RBACObjectLabels(src),
+		},
+	}
+
+}
+
+// newRoleBinding returns a RoleBinding object that binds a ServiceAccount
+// (namespace-scoped) to a ClusterRole (cluster-scoped).
+func newRoleBinding(src v1alpha1.EventSource, owner *corev1.ServiceAccount) *rbacv1.RoleBinding {
+	crGVK := rbacv1.SchemeGroupVersion.WithKind("ClusterRole")
+	saGVK := corev1.SchemeGroupVersion.WithKind("ServiceAccount")
+
+	ns := src.GetNamespace()
+	n := AdapterRBACObjectsName(src)
+
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      n,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(owner, saGVK),
+			},
+			Labels: RBACObjectLabels(src),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: crGVK.Group,
+			Kind:     crGVK.Kind,
+			Name:     n,
+		},
+		Subjects: []rbacv1.Subject{{
+			APIGroup:  saGVK.Group,
+			Kind:      saGVK.Kind,
+			Namespace: ns,
+			Name:      n,
+		}},
+	}
+}
+
+// AdapterRBACObjectsName returns a unique name to apply to all RBAC objects
+// for the given source's adapter.
+func AdapterRBACObjectsName(src kmeta.OwnerRefable) string {
+	return AdapterName(src) + "-" + componentAdapter
+}
+
+// RBACObjectLabels returns a set of labels to be applied to reconciled RBAC objects.
+func RBACObjectLabels(src kmeta.OwnerRefable) labels.Set {
+	return labels.Set{
+		appNameLabel:      AdapterName(src),
+		appComponentLabel: componentAdapter,
+		appPartOfLabel:    partOf,
+		appManagedByLabel: managedBy,
+	}
 }
 
 // MaybeAppendValueFromEnvVar conditionally appends an EnvVar to env based on

--- a/pkg/reconciler/common/base.go
+++ b/pkg/reconciler/common/base.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -23,11 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
 	coreclientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	rbacclientv1 "k8s.io/client-go/kubernetes/typed/rbac/v1"
 	appslistersv1 "k8s.io/client-go/listers/apps/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	rbaclistersv1 "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 
 	k8sclient "knative.dev/pkg/client/injection/kube/client"
 	deploymentinformerv1 "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
+	sainformerv1 "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
+	rbinformerv1 "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/resolver"
 	servingclientv1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
@@ -45,6 +50,8 @@ type GenericDeploymentReconciler struct {
 	PodClient func(namespace string) coreclientv1.PodInterface
 	// objects listers
 	Lister func(namespace string) appslistersv1.DeploymentNamespaceLister
+
+	*GenericRBACReconciler
 }
 
 // GenericServiceReconciler contains interfaces shared across Service reconcilers.
@@ -55,6 +62,18 @@ type GenericServiceReconciler struct {
 	Client func(namespace string) servingclientv1.ServiceInterface
 	// objects listers
 	Lister func(namespace string) servinglistersv1.ServiceNamespaceLister
+
+	*GenericRBACReconciler
+}
+
+// GenericRBACReconciler reconciles RBAC objects for source adapters.
+type GenericRBACReconciler struct {
+	// API clients
+	SAClient func(namespace string) coreclientv1.ServiceAccountInterface
+	RBClient func(namespace string) rbacclientv1.RoleBindingInterface
+	// objects listers
+	SALister func(namespace string) corelistersv1.ServiceAccountNamespaceLister
+	RBLister func(namespace string) rbaclistersv1.RoleBindingNamespaceLister
 }
 
 // NewGenericDeploymentReconciler creates a new GenericDeploymentReconciler and
@@ -67,10 +86,11 @@ func NewGenericDeploymentReconciler(ctx context.Context, gvk schema.GroupVersion
 	informer := deploymentinformerv1.Get(ctx)
 
 	r := GenericDeploymentReconciler{
-		SinkResolver: resolver.NewURIResolver(ctx, resolverCallback),
-		Client:       k8sclient.Get(ctx).AppsV1().Deployments,
-		PodClient:    k8sclient.Get(ctx).CoreV1().Pods,
-		Lister:       informer.Lister().Deployments,
+		SinkResolver:          resolver.NewURIResolver(ctx, resolverCallback),
+		Client:                k8sclient.Get(ctx).AppsV1().Deployments,
+		PodClient:             k8sclient.Get(ctx).CoreV1().Pods,
+		Lister:                informer.Lister().Deployments,
+		GenericRBACReconciler: NewGenericRbacReconciler(ctx),
 	}
 
 	informer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -91,9 +111,10 @@ func NewGenericServiceReconciler(ctx context.Context, gvk schema.GroupVersionKin
 	informer := serviceinformerv1.Get(ctx)
 
 	r := GenericServiceReconciler{
-		SinkResolver: resolver.NewURIResolver(ctx, resolverCallback),
-		Client:       servingclient.Get(ctx).ServingV1().Services,
-		Lister:       informer.Lister().Services,
+		SinkResolver:          resolver.NewURIResolver(ctx, resolverCallback),
+		Client:                servingclient.Get(ctx).ServingV1().Services,
+		Lister:                informer.Lister().Services,
+		GenericRBACReconciler: NewGenericRbacReconciler(ctx),
 	}
 
 	informer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -102,4 +123,14 @@ func NewGenericServiceReconciler(ctx context.Context, gvk schema.GroupVersionKin
 	})
 
 	return r
+}
+
+// NewGenericRbacReconciler creates a new GenericRbacReconciler.
+func NewGenericRbacReconciler(ctx context.Context) *GenericRBACReconciler {
+	return &GenericRBACReconciler{
+		SAClient: k8sclient.Get(ctx).CoreV1().ServiceAccounts,
+		RBClient: k8sclient.Get(ctx).RbacV1().RoleBindings,
+		SALister: sainformerv1.Get(ctx).Lister().ServiceAccounts,
+		RBLister: rbinformerv1.Get(ctx).Lister().RoleBindings,
+	}
 }

--- a/pkg/reconciler/common/doc.go
+++ b/pkg/reconciler/common/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package common contains constants shared by reconcilers.
+// Package common contains reconciliation helpers shared by source reconcilers.
 package common

--- a/pkg/reconciler/common/env.go
+++ b/pkg/reconciler/common/env.go
@@ -18,9 +18,9 @@ package common
 
 // Common environment variables propagated to adapters.
 const (
-	envName      = "NAME"
-	envNamespace = "NAMESPACE"
-	envSink      = "K_SINK"
+	EnvName      = "NAME"
+	EnvNamespace = "NAMESPACE"
 
+	envSink                  = "K_SINK"
 	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
 )

--- a/pkg/reconciler/common/events.go
+++ b/pkg/reconciler/common/events.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,15 @@ package common
 
 // Reasons for API Events
 const (
+	// ReasonRBACCreate indicates that an RBAC object was successfully created.
+	ReasonRBACCreate = "CreateRBAC"
+	// ReasonRBACUpdate indicates that an RBAC object was successfully updated.
+	ReasonRBACUpdate = "UpdateRBAC"
+	// ReasonFailedRBACCreate indicates that the creation of an RBAC object failed.
+	ReasonFailedRBACCreate = "FailedRBACCreate"
+	// ReasonFailedRBACUpdate indicates that the update of an RBAC object failed.
+	ReasonFailedRBACUpdate = "FailedRBACUpdate"
+
 	// ReasonAdapterCreate indicates that an adapter object was successfully created.
 	ReasonAdapterCreate = "CreateAdapter"
 	// ReasonAdapterUpdate indicates that an adapter object was successfully updated.

--- a/pkg/reconciler/common/reconcile.go
+++ b/pkg/reconciler/common/reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,9 +19,11 @@ package common
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -29,6 +31,7 @@ import (
 
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/serving/pkg/apis/serving"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -45,11 +48,28 @@ var knativeServingAnnotations = []string{
 	serving.UpdaterAnnotation,
 }
 
-// AdapterDeploymentBuilderFunc builds a Deployment object for a source's adapter.
-type AdapterDeploymentBuilderFunc func(sinkURI *apis.URL) *appsv1.Deployment
+// RBACOwnersLister returns a list of OwnerRefable to be set as a the
+// OwnerReferences metadata attribute of a ServiceAccount.
+type RBACOwnersLister interface {
+	RBACOwners(namespace string) ([]kmeta.OwnerRefable, error)
+}
+
+// AdapterDeploymentBuilder provides all the necessary information for building
+// objects related to a source's adapter backed by a Deployment.
+type AdapterDeploymentBuilder interface {
+	RBACOwnersLister
+	BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *appsv1.Deployment
+}
+
+// AdapterServiceBuilder provides all the necessary information for building
+// objects related to a source's adapter backed by a Knative Service.
+type AdapterServiceBuilder interface {
+	RBACOwnersLister
+	BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *servingv1.Service
+}
 
 // ReconcileSource reconciles an event source type.
-func (r *GenericDeploymentReconciler) ReconcileSource(ctx context.Context, adb AdapterDeploymentBuilderFunc) reconciler.Event {
+func (r *GenericDeploymentReconciler) ReconcileSource(ctx context.Context, ab AdapterDeploymentBuilder) reconciler.Event {
 	src := v1alpha1.SourceFromContext(ctx)
 
 	src.GetStatusManager().CloudEventAttributes = CreateCloudEventAttributes(
@@ -63,7 +83,14 @@ func (r *GenericDeploymentReconciler) ReconcileSource(ctx context.Context, adb A
 	}
 	src.GetStatusManager().MarkSink(sinkURI)
 
-	if err := r.reconcileAdapter(ctx, adb(sinkURI)); err != nil {
+	desiredAdapter := ab.BuildAdapter(src, sinkURI)
+
+	saOwners, err := ab.RBACOwners(src.GetNamespace())
+	if err != nil {
+		return fmt.Errorf("listing ServiceAccount owners: %w", err)
+	}
+
+	if err := r.reconcileAdapter(ctx, desiredAdapter, saOwners); err != nil {
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 	return nil
@@ -82,8 +109,15 @@ func (r *GenericDeploymentReconciler) resolveSinkURL(ctx context.Context) (*apis
 }
 
 // reconcileAdapter reconciles the state of the source's adapter.
-func (r *GenericDeploymentReconciler) reconcileAdapter(ctx context.Context, desiredAdapter *appsv1.Deployment) error {
+func (r *GenericDeploymentReconciler) reconcileAdapter(ctx context.Context,
+	desiredAdapter *appsv1.Deployment, rbacOwners []kmeta.OwnerRefable) error {
+
 	src := v1alpha1.SourceFromContext(ctx)
+
+	if err := r.reconcileRBAC(ctx, rbacOwners); err != nil {
+		src.GetStatusManager().MarkRBACNotBound()
+		return fmt.Errorf("reconciling RBAC objects: %w", err)
+	}
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
@@ -157,11 +191,8 @@ func (r *GenericDeploymentReconciler) syncAdapterDeployment(ctx context.Context,
 	return adapter, nil
 }
 
-// AdapterServiceBuilderFunc builds a Service object for a source's adapter.
-type AdapterServiceBuilderFunc func(sinkURI *apis.URL) *servingv1.Service
-
 // ReconcileSource reconciles an event source type.
-func (r *GenericServiceReconciler) ReconcileSource(ctx context.Context, adb AdapterServiceBuilderFunc) reconciler.Event {
+func (r *GenericServiceReconciler) ReconcileSource(ctx context.Context, ab AdapterServiceBuilder) reconciler.Event {
 	src := v1alpha1.SourceFromContext(ctx)
 
 	src.GetStatusManager().CloudEventAttributes = CreateCloudEventAttributes(
@@ -175,7 +206,14 @@ func (r *GenericServiceReconciler) ReconcileSource(ctx context.Context, adb Adap
 	}
 	src.GetStatusManager().MarkSink(sinkURI)
 
-	if err := r.reconcileAdapter(ctx, adb(sinkURI)); err != nil {
+	desiredAdapter := ab.BuildAdapter(src, sinkURI)
+
+	saOwners, err := ab.RBACOwners(src.GetNamespace())
+	if err != nil {
+		return fmt.Errorf("listing ServiceAccount owners: %w", err)
+	}
+
+	if err := r.reconcileAdapter(ctx, desiredAdapter, saOwners); err != nil {
 		return fmt.Errorf("failed to reconcile adapter: %w", err)
 	}
 	return nil
@@ -194,8 +232,15 @@ func (r *GenericServiceReconciler) resolveSinkURL(ctx context.Context) (*apis.UR
 }
 
 // reconcileAdapter reconciles the state of the source's adapter.
-func (r *GenericServiceReconciler) reconcileAdapter(ctx context.Context, desiredAdapter *servingv1.Service) error {
+func (r *GenericServiceReconciler) reconcileAdapter(ctx context.Context,
+	desiredAdapter *servingv1.Service, rbacOwners []kmeta.OwnerRefable) error {
+
 	src := v1alpha1.SourceFromContext(ctx)
+
+	if err := r.reconcileRBAC(ctx, rbacOwners); err != nil {
+		src.GetStatusManager().MarkRBACNotBound()
+		return fmt.Errorf("reconciling RBAC objects: %w", err)
+	}
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
 	if err != nil {
@@ -330,4 +375,154 @@ func newNotFoundForSelector(gr schema.GroupResource, sel labels.Selector) *apier
 	err := apierrors.NewNotFound(gr, "")
 	err.ErrStatus.Message = fmt.Sprint(gr, " not found for selector ", sel)
 	return err
+}
+
+// reconcileRBAC wraps the reconciliation logic for RBAC objects.
+func (r *GenericRBACReconciler) reconcileRBAC(ctx context.Context, owners []kmeta.OwnerRefable) error {
+	// The ServiceAccount's ownership is shared between all instances of a
+	// given source type. It gets garbage collected by Kubernetes as soon
+	// as its last owner (source) is deleted, so we don't need to clean
+	// things up explicitly once the last source gets deleted.
+	if len(owners) == 0 {
+		return nil
+	}
+
+	src := v1alpha1.SourceFromContext(ctx)
+
+	desiredSA := newServiceAccount(src, owners)
+	currentSA, err := r.getOrCreateAdapterServiceAccount(ctx, desiredSA)
+	if err != nil {
+		return err
+	}
+
+	desiredRB := newRoleBinding(src, currentSA)
+	currentRB, err := r.getOrCreateAdapterRoleBinding(ctx, desiredRB)
+	if err != nil {
+		return err
+	}
+
+	if _, err = r.syncAdapterServiceAccount(ctx, currentSA, desiredSA); err != nil {
+		return fmt.Errorf("synchronizing adapter ServiceAccount: %w", err)
+	}
+
+	if _, err = r.syncAdapterRoleBinding(ctx, currentRB, desiredRB); err != nil {
+		return fmt.Errorf("synchronizing adapter RoleBinding: %w", err)
+	}
+
+	return nil
+}
+
+// getOrCreateAdapterServiceAccount returns the existing adapter ServiceAccount
+// for a given source, or creates it if it is missing.
+func (r *GenericRBACReconciler) getOrCreateAdapterServiceAccount(ctx context.Context,
+	desiredSA *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+
+	src := v1alpha1.SourceFromContext(ctx)
+
+	sa, err := r.SALister(src.GetNamespace()).Get(desiredSA.Name)
+	switch {
+	case apierrors.IsNotFound(err):
+		sa, err = r.SAClient(desiredSA.Namespace).Create(ctx, desiredSA, metav1.CreateOptions{})
+		if err != nil {
+			return nil, reconciler.NewEvent(corev1.EventTypeWarning, ReasonFailedRBACCreate,
+				"Failed to create adapter ServiceAccount %q: %s", desiredSA.Name, err)
+		}
+		controller.GetEventRecorder(ctx).Eventf(newNamespace(desiredSA.Namespace), corev1.EventTypeNormal,
+			ReasonRBACCreate, "Created ServiceAccount %q due to the creation of a %s object",
+			sa.Name, src.GetGroupVersionKind().Kind)
+
+	case err != nil:
+		return nil, fmt.Errorf("getting adapter ServiceAccount from cache: %w", err)
+	}
+
+	return sa, nil
+}
+
+// syncAdapterServiceAccount synchronizes the desired state of an adapter
+// ServiceAccount against its current state in the running cluster.
+func (r *GenericRBACReconciler) syncAdapterServiceAccount(ctx context.Context,
+	currentSA, desiredSA *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+
+	if reflect.DeepEqual(desiredSA.OwnerReferences, currentSA.OwnerReferences) {
+		return currentSA, nil
+	}
+
+	// resourceVersion must be returned to the API server unmodified for
+	// optimistic concurrency, as per Kubernetes API conventions
+	desiredSA.ResourceVersion = currentSA.ResourceVersion
+
+	sa, err := r.SAClient(desiredSA.Namespace).Update(ctx, desiredSA, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, reconciler.NewEvent(corev1.EventTypeWarning, ReasonFailedRBACUpdate,
+			"Failed to update adapter ServiceAccount %q: %s", desiredSA.Name, err)
+	}
+
+	controller.GetEventRecorder(ctx).Eventf(newNamespace(sa.Namespace), corev1.EventTypeNormal,
+		ReasonRBACUpdate, "Updated ServiceAccount %q due to the creation/deletion of a %s object",
+		sa.Name, v1alpha1.SourceFromContext(ctx).GetGroupVersionKind().Kind)
+
+	return sa, nil
+}
+
+// getOrCreateAdapterRoleBinding returns the existing adapter RoleBinding, or
+// creates it if it is missing.
+func (r *GenericRBACReconciler) getOrCreateAdapterRoleBinding(ctx context.Context,
+	desiredRB *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+
+	src := v1alpha1.SourceFromContext(ctx)
+
+	rb, err := r.RBLister(desiredRB.Namespace).Get(desiredRB.Name)
+	switch {
+	case apierrors.IsNotFound(err):
+		rb, err = r.RBClient(src.GetNamespace()).Create(ctx, desiredRB, metav1.CreateOptions{})
+		if err != nil {
+			return nil, reconciler.NewEvent(corev1.EventTypeWarning, ReasonFailedRBACCreate,
+				"Failed to create adapter RoleBinding %q: %s", desiredRB.Name, err)
+		}
+		controller.GetEventRecorder(ctx).Eventf(newNamespace(rb.Namespace), corev1.EventTypeNormal,
+			ReasonRBACCreate, "Created RoleBinding %q due to the creation of a %s object",
+			rb.Name, src.GetGroupVersionKind().Kind)
+
+	case err != nil:
+		return nil, fmt.Errorf("getting adapter RoleBinding from cache: %w", err)
+	}
+
+	return rb, nil
+}
+
+// syncAdapterRoleBinding synchronizes the desired state of an adapter
+// RoleBinding against its current state in the running cluster.
+func (r *GenericRBACReconciler) syncAdapterRoleBinding(ctx context.Context,
+	currentRB, desiredRB *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
+
+	if reflect.DeepEqual(desiredRB.OwnerReferences, currentRB.OwnerReferences) &&
+		reflect.DeepEqual(desiredRB.RoleRef, currentRB.RoleRef) &&
+		reflect.DeepEqual(desiredRB.Subjects, currentRB.Subjects) {
+
+		return currentRB, nil
+	}
+
+	// resourceVersion must be returned to the API server unmodified for
+	// optimistic concurrency, as per Kubernetes API conventions
+	desiredRB.ResourceVersion = currentRB.ResourceVersion
+
+	rb, err := r.RBClient(desiredRB.Namespace).Update(ctx, desiredRB, metav1.UpdateOptions{})
+	if err != nil {
+		return nil, reconciler.NewEvent(corev1.EventTypeWarning, ReasonFailedRBACUpdate,
+			"Failed to update adapter RoleBinding %q: %s", desiredRB.Name, err)
+	}
+	controller.GetEventRecorder(ctx).Eventf(newNamespace(rb.Namespace), corev1.EventTypeNormal,
+		ReasonRBACUpdate, "Updated RoleBinding %q", rb.Name)
+
+	return rb, nil
+}
+
+// newNamespace returns a Namespace object with the given name.
+// It is used as a helper to record namespace-scoped API events.
+func newNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
 }

--- a/pkg/reconciler/common/resource/deployment_test.go
+++ b/pkg/reconciler/common/resource/deployment_test.go
@@ -44,6 +44,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
+		ServiceAccount("god-mode"),
 		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		TerminationErrorToLogs,
@@ -75,6 +76,7 @@ func TestNewDeploymentWithDefaultContainer(t *testing.T) {
 					},
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: "god-mode",
 					Containers: []corev1.Container{{
 						Name:  defaultContainerName,
 						Image: tImg,

--- a/pkg/reconciler/common/resource/knservice_test.go
+++ b/pkg/reconciler/common/resource/knservice_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 		EnvVars(makeEnvVars(2, "MULTI_ENV", "val")...),
 		EnvVar("TEST_ENV2", "val2"),
 		Label("test.label/2", "val2"),
+		ServiceAccount("god-mode"),
 		Requests(resource.MustParse("250m"), resource.MustParse("100Mi")),
 		Limits(resource.MustParse("250m"), resource.MustParse("100Mi")),
 	)
@@ -65,6 +66,7 @@ func TestNewServiceWithDefaultContainer(t *testing.T) {
 					},
 					Spec: servingv1.RevisionSpec{
 						PodSpec: corev1.PodSpec{
+							ServiceAccountName: "god-mode",
 							Containers: []corev1.Container{{
 								Name:  defaultContainerName,
 								Image: tImg,

--- a/pkg/reconciler/common/resource/podspecable.go
+++ b/pkg/reconciler/common/resource/podspecable.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -51,5 +51,21 @@ func Container(c *corev1.Container) ObjectOption {
 			containers := &o.Spec.Template.Spec.Containers
 			*containers = []corev1.Container{*c}
 		}
+	}
+}
+
+// ServiceAccount sets the ServiceAccount name of a PodSpecable.
+func ServiceAccount(sa string) ObjectOption {
+	return func(object interface{}) {
+		var saName *string
+
+		switch o := object.(type) {
+		case *appsv1.Deployment:
+			saName = &o.Spec.Template.Spec.ServiceAccountName
+		case *servingv1.Service:
+			saName = &o.Spec.Template.Spec.ServiceAccountName
+		}
+
+		*saName = sa
 	}
 }

--- a/pkg/reconciler/httpsource/adapter.go
+++ b/pkg/reconciler/httpsource/adapter.go
@@ -17,10 +17,14 @@ limitations under the License.
 package httpsource
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
@@ -45,17 +49,34 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterServiceBuilder returns an AdapterServiceBuilderFunc for the
-// given source object and adapter config.
-func adapterServiceBuilder(src *v1alpha1.HTTPSource, cfg *adapterConfig) common.AdapterServiceBuilderFunc {
-	return func(sinkURI *apis.URL) *servingv1.Service {
-		return common.NewAdapterKnService(src, sinkURI,
-			resource.Image(cfg.Image),
+// Verify that Reconciler implements common.AdapterServiceBuilder.
+var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 
-			resource.EnvVars(makeHTTPEnvs(src)...),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *servingv1.Service {
+	typedSrc := src.(*v1alpha1.HTTPSource)
+
+	return common.NewAdapterKnService(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVars(makeHTTPEnvs(typedSrc)...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }
 
 func makeHTTPEnvs(src *v1alpha1.HTTPSource) []corev1.EnvVar {

--- a/pkg/reconciler/httpsource/controller.go
+++ b/pkg/reconciler/httpsource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,8 +46,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().HTTPSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -58,7 +61,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/httpsource/controller_test.go
+++ b/pkg/reconciler/httpsource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,8 @@ import (
 	// Link fake informers accessed by our controller
 	_ "github.com/triggermesh/knative-sources/pkg/client/generated/injection/informers/sources/v1alpha1/httpsource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/service/fake"
 )

--- a/pkg/reconciler/httpsource/reconciler.go
+++ b/pkg/reconciler/httpsource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/httpsource"
+	listersv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericServiceReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.HTTPSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.HTTPSource
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterServiceBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/httpsource/reconciler_test.go
+++ b/pkg/reconciler/httpsource/reconciler_test.go
@@ -20,13 +20,10 @@ import (
 	"context"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/resolver"
-	fakeservinginjectionclient "knative.dev/serving/pkg/client/injection/client/fake"
+	rt "knative.dev/pkg/reconciler/testing"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
 	fakeinjectionclient "github.com/triggermesh/knative-sources/pkg/client/generated/injection/client/fake"
@@ -41,27 +38,20 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterServiceBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
-// reconcilerCtor returns a Ctor for a Source Reconciler.
+// reconcilerCtor returns a Ctor for a source Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
-		base := common.GenericServiceReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetServiceLister().Services,
-			Client:       fakeservinginjectionclient.Get(ctx).ServingV1().Services,
-		}
-
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		r := &Reconciler{
-			base:       base,
+			base:       NewTestServiceReconciler(ctx, ls),
 			adapterCfg: cfg,
+			srcLister:  ls.GetHTTPSourceLister().HTTPSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -81,4 +71,12 @@ func newEventSource() *v1alpha1.HTTPSource {
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }

--- a/pkg/reconciler/slacksource/adapter.go
+++ b/pkg/reconciler/slacksource/adapter.go
@@ -17,10 +17,14 @@ limitations under the License.
 package slacksource
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
@@ -43,17 +47,34 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterServiceBuilder returns an AdapterServiceBuilderFunc for the
-// given source object and adapter config.
-func adapterServiceBuilder(src *v1alpha1.SlackSource, cfg *adapterConfig) common.AdapterServiceBuilderFunc {
-	return func(sinkURI *apis.URL) *servingv1.Service {
-		return common.NewAdapterKnService(src, sinkURI,
-			resource.Image(cfg.Image),
+// Verify that Reconciler implements common.AdapterServiceBuilder.
+var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 
-			resource.EnvVars(makeSlackEnvs(src)...),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *servingv1.Service {
+	typedSrc := src.(*v1alpha1.SlackSource)
+
+	return common.NewAdapterKnService(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVars(makeSlackEnvs(typedSrc)...),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }
 
 func makeSlackEnvs(src *v1alpha1.SlackSource) []corev1.EnvVar {

--- a/pkg/reconciler/slacksource/controller.go
+++ b/pkg/reconciler/slacksource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -47,8 +47,11 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg: adapterCfg,
+		srcLister:  informer.Lister().SlackSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -59,7 +62,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+	informer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	return impl
 }

--- a/pkg/reconciler/slacksource/controller_test.go
+++ b/pkg/reconciler/slacksource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,8 @@ import (
 	// Link fake informers accessed by our controller
 	_ "github.com/triggermesh/knative-sources/pkg/client/generated/injection/informers/sources/v1alpha1/slacksource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/service/fake"
 )

--- a/pkg/reconciler/slacksource/reconciler.go
+++ b/pkg/reconciler/slacksource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,6 +23,7 @@ import (
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/slacksource"
+	listersv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 )
 
@@ -30,6 +31,8 @@ import (
 type Reconciler struct {
 	base       common.GenericServiceReconciler
 	adapterCfg *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.SlackSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -40,5 +43,5 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.SlackSourc
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	return r.base.ReconcileSource(ctx, adapterServiceBuilder(src, r.adapterCfg))
+	return r.base.ReconcileSource(ctx, r)
 }

--- a/pkg/reconciler/testing/controller.go
+++ b/pkg/reconciler/testing/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -40,8 +40,8 @@ func TestControllerConstructor(t *testing.T, ctor injection.ControllerConstructo
 
 	ctx, informers := rt.SetupFakeContext(t)
 
-	// expected informers: Source, Deployment
-	if expect, got := 2, len(informers); got != expect {
+	// expected informers: Source, Deployment, ServiceAccount, RoleBinding
+	if expect, got := 4, len(informers); got != expect {
 		t.Errorf("Expected %d injected informers, got %d", expect, got)
 	}
 

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -36,8 +36,8 @@ import (
 	"knative.dev/pkg/resolver"
 	fakeservinginjectionclient "knative.dev/serving/pkg/client/injection/client/fake"
 
-	"github.com/triggermesh/event-sources/pkg/reconciler/common"
 	fakeinjectionclient "github.com/triggermesh/knative-sources/pkg/client/generated/injection/client/fake"
+	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 )
 
 // Ctor constructs a controller.Reconciler.

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,9 +20,13 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
-	k8slistersv1 "k8s.io/client-go/listers/apps/v1"
+	appslistersv1 "k8s.io/client-go/listers/apps/v1"
+	corelistersv1 "k8s.io/client-go/listers/core/v1"
+	rbaclistersv1 "k8s.io/client-go/listers/rbac/v1"
 	"k8s.io/client-go/tools/cache"
 
 	fakeeventingclientset "knative.dev/eventing/pkg/client/clientset/versioned/fake"
@@ -110,11 +114,21 @@ func (l *Listers) GetHTTPSourceLister() listersv1alpha1.HTTPSourceLister {
 }
 
 // GetDeploymentLister returns a lister for Deployment objects.
-func (l *Listers) GetDeploymentLister() k8slistersv1.DeploymentLister {
-	return k8slistersv1.NewDeploymentLister(l.IndexerFor(&appsv1.Deployment{}))
+func (l *Listers) GetDeploymentLister() appslistersv1.DeploymentLister {
+	return appslistersv1.NewDeploymentLister(l.IndexerFor(&appsv1.Deployment{}))
 }
 
-// GetServiceLister returns a lister for Service objects.
+// GetServiceLister returns a lister for Knative Service objects.
 func (l *Listers) GetServiceLister() servinglistersv1.ServiceLister {
 	return servinglistersv1.NewServiceLister(l.IndexerFor(&servingv1.Service{}))
+}
+
+// GetServiceAccountLister returns a lister for ServiceAccount objects.
+func (l *Listers) GetServiceAccountLister() corelistersv1.ServiceAccountLister {
+	return corelistersv1.NewServiceAccountLister(l.IndexerFor(&corev1.ServiceAccount{}))
+}
+
+// GetRoleBindingLister returns a lister for RoleBinding objects
+func (l *Listers) GetRoleBindingLister() rbaclistersv1.RoleBindingLister {
+	return rbaclistersv1.NewRoleBindingLister(l.IndexerFor(&rbacv1.RoleBinding{}))
 }

--- a/pkg/reconciler/testing/reconcile.go
+++ b/pkg/reconciler/testing/reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,6 +35,8 @@ import (
 	eventingv1 "knative.dev/eventing/pkg/apis/eventing/v1"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
 	"knative.dev/pkg/reconciler"
 	rt "knative.dev/pkg/reconciler/testing"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -64,19 +67,24 @@ var (
 	}
 )
 
-// Test the Reconcile method of the controller.Reconciler implemented by controllers.
+// Test the Reconcile() method of the controller.Reconciler implemented by
+// source Reconcilers, with focus on the generic ReconcileSource logic executed
+// by the generic adapter reconciler embedded in every source Reconciler.
 //
 // The environment for each test case is set up as follows:
 //  1. MakeFactory initializes fake clients with the objects declared in the test case
 //  2. MakeFactory injects those clients into a context along with fake event recorders, etc.
 //  3. A Reconciler is constructed via a Ctor function using the values injected above
 //  4. The Reconciler returned by MakeFactory is used to run the test case
-func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn interface{}) {
+func TestReconcileAdapter(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterBuilder interface{}) {
 	assertPopulatedSource(t, src)
 
 	newEventSource := eventSourceCtor(src)
-	newAdapter := adapterCtor(adapterFn, src)
+	newServiceAccount := NewServiceAccount(src)
+	newRoleBinding := NewRoleBinding(newServiceAccount())
+	newAdapter := adapterCtor(adapterBuilder, src)
 
+	s := newEventSource()
 	a := newAdapter()
 	n, k, r := nameKindAndResource(a)
 
@@ -96,12 +104,16 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 				newEventSource(noCEAttributes),
 			},
 			WantCreates: []runtime.Object{
+				newServiceAccount(),
+				newRoleBinding(),
 				newAdapter(),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
 				Object: newEventSource(withSink, notDeployed(a)),
 			}},
 			WantEvents: []string{
+				createServiceAccountEvent(s),
+				createRoleBindingEvent(s),
 				createAdapterEvent(n, k),
 			},
 		},
@@ -123,6 +135,8 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 			Objects: []runtime.Object{
 				newAdressable(),
 				newEventSource(withSink, notDeployed(a)),
+				newServiceAccount(),
+				newRoleBinding(),
 				newAdapter(ready),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -136,6 +150,8 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 			Objects: []runtime.Object{
 				newAdressable(),
 				newEventSource(withSink, deployed(a)),
+				newServiceAccount(),
+				newRoleBinding(),
 				newAdapter(notReady),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -149,6 +165,8 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 			Objects: []runtime.Object{
 				newAdressable(),
 				newEventSource(withSink, deployed(a)),
+				newServiceAccount(),
+				newRoleBinding(),
 				newAdapter(ready, bumpImage),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -167,6 +185,8 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 			Objects: []runtime.Object{
 				/* sink omitted */
 				newEventSource(withSink, deployed(a)),
+				newServiceAccount(),
+				newRoleBinding(),
 				newAdapter(ready),
 			},
 			WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
@@ -186,6 +206,8 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 			Objects: []runtime.Object{
 				newAdressable(),
 				newEventSource(withSink),
+				newServiceAccount(),
+				newRoleBinding(),
 			},
 			WantCreates: []runtime.Object{
 				newAdapter(),
@@ -207,6 +229,8 @@ func TestReconcile(t *testing.T, ctor Ctor, src v1alpha1.EventSource, adapterFn 
 			Objects: []runtime.Object{
 				newAdressable(),
 				newEventSource(withSink, deployed(a)),
+				newServiceAccount(),
+				newRoleBinding(),
 				newAdapter(ready, bumpImage),
 			},
 			WantUpdates: []clientgotesting.UpdateActionImpl{{
@@ -384,15 +408,15 @@ type adapterCtorWithOptions func(...adapterOption) runtime.Object
 
 // adapterCtor creates a copy of the given adapter object and returns a
 // function that can apply options to that object.
-func adapterCtor(adapterFn interface{}, src v1alpha1.EventSource) adapterCtorWithOptions {
+func adapterCtor(adapterBuilder interface{}, src v1alpha1.EventSource) adapterCtorWithOptions {
 	return func(opts ...adapterOption) runtime.Object {
 		var obj runtime.Object
 
-		switch typedAdapterFn := adapterFn.(type) {
-		case common.AdapterDeploymentBuilderFunc:
-			obj = typedAdapterFn(tSinkURI)
-		case common.AdapterServiceBuilderFunc:
-			obj = typedAdapterFn(tSinkURI)
+		switch typedAdapterBuilder := adapterBuilder.(type) {
+		case common.AdapterDeploymentBuilder:
+			obj = typedAdapterBuilder.BuildAdapter(src, tSinkURI)
+		case common.AdapterServiceBuilder:
+			obj = typedAdapterBuilder.BuildAdapter(src, tSinkURI)
 		}
 
 		for _, opt := range opts {
@@ -470,8 +494,76 @@ func newAdressable() *eventingv1.Broker {
 	}
 }
 
+/* RBAC */
+
+func NewServiceAccount(src kmeta.OwnerRefable) func() *corev1.ServiceAccount {
+	name := common.AdapterName(src) + "-adapter"
+	labels := common.RBACObjectLabels(src)
+
+	return func() *corev1.ServiceAccount {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: tNs,
+				Name:      name,
+				Labels:    labels,
+				OwnerReferences: []metav1.OwnerReference{
+					*kmeta.NewControllerRef(src),
+				},
+			},
+		}
+		sa.OwnerReferences[0].Controller = ptr.Bool(false)
+
+		return sa
+	}
+}
+
+func NewRoleBinding(sa *corev1.ServiceAccount) func() *rbacv1.RoleBinding {
+	return func() *rbacv1.RoleBinding {
+		return &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: tNs,
+				Name:      sa.Name,
+				Labels:    sa.Labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "v1",
+						Kind:               "ServiceAccount",
+						Name:               sa.Name,
+						UID:                sa.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     sa.Name,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					APIGroup:  "",
+					Kind:      "ServiceAccount",
+					Namespace: tNs,
+					Name:      sa.Name,
+				},
+			},
+		}
+	}
+}
+
 /* Events */
 
+func createServiceAccountEvent(src kmeta.OwnerRefable) string {
+	return eventtesting.Eventf(corev1.EventTypeNormal, common.ReasonRBACCreate,
+		"Created ServiceAccount %q due to the creation of a %s object",
+		common.AdapterRBACObjectsName(src), src.GetGroupVersionKind().Kind)
+}
+func createRoleBindingEvent(src kmeta.OwnerRefable) string {
+	return eventtesting.Eventf(corev1.EventTypeNormal, common.ReasonRBACCreate,
+		"Created RoleBinding %q due to the creation of a %s object",
+		common.AdapterRBACObjectsName(src), src.GetGroupVersionKind().Kind)
+}
 func createAdapterEvent(name, kind string) string {
 	return eventtesting.Eventf(corev1.EventTypeNormal, common.ReasonAdapterCreate, "Created adapter %s %q", kind, name)
 }

--- a/pkg/reconciler/zendesksource/adapter.go
+++ b/pkg/reconciler/zendesksource/adapter.go
@@ -17,8 +17,12 @@ limitations under the License.
 package zendesksource
 
 import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/labels"
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/kmeta"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
@@ -42,19 +46,36 @@ type adapterConfig struct {
 	configs source.ConfigAccessor
 }
 
-// adapterServiceBuilder returns an AdapterServiceBuilderFunc for the
-// given source object and adapter config.
-func adapterServiceBuilder(src *v1alpha1.ZendeskSource, cfg *adapterConfig) common.AdapterServiceBuilderFunc {
-	return func(sinkURI *apis.URL) *servingv1.Service {
-		return common.NewAdapterKnService(src, sinkURI,
-			resource.Image(cfg.Image),
+// Verify that Reconciler implements common.AdapterServiceBuilder.
+var _ common.AdapterServiceBuilder = (*Reconciler)(nil)
 
-			resource.EnvVar(envZdSubdomain, src.Spec.Subdomain),
-			resource.EnvVar(envZdWebhookUser, src.Spec.WebhookUsername),
-			resource.EnvVars(common.MaybeAppendValueFromEnvVar(nil,
-				envZdWebhookPwd, src.Spec.WebhookPassword)...,
-			),
-			resource.EnvVars(cfg.configs.ToEnvVars()...),
-		)
+// BuildAdapter implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) BuildAdapter(src v1alpha1.EventSource, sinkURI *apis.URL) *servingv1.Service {
+	typedSrc := src.(*v1alpha1.ZendeskSource)
+
+	return common.NewAdapterKnService(src, sinkURI,
+		resource.Image(r.adapterCfg.Image),
+
+		resource.EnvVar(envZdSubdomain, typedSrc.Spec.Subdomain),
+		resource.EnvVar(envZdWebhookUser, typedSrc.Spec.WebhookUsername),
+		resource.EnvVars(common.MaybeAppendValueFromEnvVar(nil,
+			envZdWebhookPwd, typedSrc.Spec.WebhookPassword)...,
+		),
+		resource.EnvVars(r.adapterCfg.configs.ToEnvVars()...),
+	)
+}
+
+// RBACOwners implements common.AdapterDeploymentBuilder.
+func (r *Reconciler) RBACOwners(namespace string) ([]kmeta.OwnerRefable, error) {
+	srcs, err := r.srcLister(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("listing objects from cache: %w", err)
 	}
+
+	ownerRefables := make([]kmeta.OwnerRefable, len(srcs))
+	for i := range srcs {
+		ownerRefables[i] = srcs[i]
+	}
+
+	return ownerRefables, nil
 }

--- a/pkg/reconciler/zendesksource/controller.go
+++ b/pkg/reconciler/zendesksource/controller.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -53,9 +53,12 @@ func NewController(
 	}
 	envconfig.MustProcess(app, adapterCfg)
 
+	informer := informerv1alpha1.Get(ctx)
+
 	r := &Reconciler{
 		adapterCfg:   adapterCfg,
 		secretClient: kubeclient.Get(ctx).CoreV1().Secrets,
+		srcLister:    informer.Lister().ZendeskSources,
 	}
 	impl := reconcilerv1alpha1.NewImpl(ctx, r)
 
@@ -66,7 +69,7 @@ func NewController(
 		impl.EnqueueControllerOf,
 	)
 
-	informerv1alpha1.Get(ctx).Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), informerResyncPeriod)
+	informer.Informer().AddEventHandlerWithResyncPeriod(controller.HandleAll(impl.Enqueue), informerResyncPeriod)
 
 	return impl
 }

--- a/pkg/reconciler/zendesksource/controller_test.go
+++ b/pkg/reconciler/zendesksource/controller_test.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,6 +24,8 @@ import (
 	// Link fake informers accessed by our controller
 	_ "github.com/triggermesh/knative-sources/pkg/client/generated/injection/informers/sources/v1alpha1/zendesksource/fake"
 	_ "knative.dev/pkg/client/injection/ducks/duck/v1/addressable/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount/fake"
+	_ "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 	_ "knative.dev/serving/pkg/client/injection/informers/serving/v1/service/fake"
 )

--- a/pkg/reconciler/zendesksource/reconciler.go
+++ b/pkg/reconciler/zendesksource/reconciler.go
@@ -1,11 +1,11 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,7 @@ import (
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
 	reconcilerv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/injection/reconciler/sources/v1alpha1/zendesksource"
+	listersv1alpha1 "github.com/triggermesh/knative-sources/pkg/client/generated/listers/sources/v1alpha1"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
 )
 
@@ -33,6 +34,8 @@ type Reconciler struct {
 	base         common.GenericServiceReconciler
 	secretClient func(namespace string) coreclientv1.SecretInterface
 	adapterCfg   *adapterConfig
+
+	srcLister func(namespace string) listersv1alpha1.ZendeskSourceNamespaceLister
 }
 
 // Check that our Reconciler implements Interface
@@ -46,7 +49,7 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, src *v1alpha1.ZendeskSou
 	// inject source into context for usage in reconciliation logic
 	ctx = v1alpha1.WithSource(ctx, src)
 
-	if err := r.base.ReconcileSource(ctx, adapterServiceBuilder(src, r.adapterCfg)); err != nil {
+	if err := r.base.ReconcileSource(ctx, r); err != nil {
 		return fmt.Errorf("failed to reconcile source: %w", err)
 	}
 

--- a/pkg/reconciler/zendesksource/reconciler_test.go
+++ b/pkg/reconciler/zendesksource/reconciler_test.go
@@ -21,14 +21,12 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 
 	"knative.dev/eventing/pkg/reconciler/source"
+	fakek8sinjectionclient "knative.dev/pkg/client/injection/kube/client/fake"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
-	"knative.dev/pkg/resolver"
-	fakeservinginjectionclient "knative.dev/serving/pkg/client/injection/client/fake"
+	rt "knative.dev/pkg/reconciler/testing"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources"
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
@@ -44,28 +42,21 @@ func TestReconcileSource(t *testing.T) {
 		configs: &source.EmptyVarsGenerator{},
 	}
 
-	var (
-		ctor      = reconcilerCtor(adapterCfg)
-		src       = newEventSource()
-		adapterFn = adapterServiceBuilder(src, adapterCfg)
-	)
+	ctor := reconcilerCtor(adapterCfg)
+	src := newEventSource()
+	ab := adapterBuilder(adapterCfg)
 
-	TestReconcile(t, ctor, src, adapterFn)
+	TestReconcileAdapter(t, ctor, src, ab)
 }
 
 // reconcilerCtor returns a Ctor for a source Reconciler.
 func reconcilerCtor(cfg *adapterConfig) Ctor {
-	return func(t *testing.T, ctx context.Context, ls *Listers) controller.Reconciler {
-		base := common.GenericServiceReconciler{
-			SinkResolver: resolver.NewURIResolver(ctx, func(types.NamespacedName) {}),
-			Lister:       ls.GetServiceLister().Services,
-			Client:       fakeservinginjectionclient.Get(ctx).ServingV1().Services,
-		}
-
+	return func(t *testing.T, ctx context.Context, _ *rt.TableRow, ls *Listers) controller.Reconciler {
 		r := &Reconciler{
-			base:         base,
+			base:         NewTestServiceReconciler(ctx, ls),
 			secretClient: fakek8sinjectionclient.Get(ctx).CoreV1().Secrets,
 			adapterCfg:   cfg,
+			srcLister:    ls.GetZendeskSourceLister().ZendeskSources,
 		}
 
 		return reconcilerv1alpha1.NewReconciler(ctx, logging.FromContext(ctx),
@@ -107,4 +98,12 @@ func newEventSource() *v1alpha1.ZendeskSource {
 	Populate(src)
 
 	return src
+}
+
+// adapterBuilder returns a slim Reconciler containing only the fields accessed
+// by r.BuildAdapter().
+func adapterBuilder(cfg *adapterConfig) common.AdapterServiceBuilder {
+	return &Reconciler{
+		adapterCfg: cfg,
+	}
 }


### PR DESCRIPTION
Sync changes from https://github.com/triggermesh/aws-event-sources/pull/259, no other change introduced.