### PR TITLE
Sync lib changes for multi-tenancy

### DIFF
--- a/config/201-serviceaccounts.yaml
+++ b/config/201-serviceaccounts.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 TriggerMesh Inc.
+# Copyright (c) 2020-2021 TriggerMesh Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,34 +17,3 @@ kind: ServiceAccount
 metadata:
   name: knative-sources-controller
   namespace: triggermesh
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: &app knative-sources-controller
-subjects:
-- kind: ServiceAccount
-  name: *app
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: *app
-
----
-
-# Resolve sink URIs
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: knative-sources-controller-addressable-resolver
-subjects:
-- kind: ServiceAccount
-  name: knative-sources-controller
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: addressable-resolver

--- a/config/202-clusterrolebindings.yaml
+++ b/config/202-clusterrolebindings.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) 2021 TriggerMesh Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app knative-sources-controller
+subjects:
+- kind: ServiceAccount
+  name: *app
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+
+---
+
+# Permissions not required by controllers directly, but granted to
+# receive-adapters via RoleBindings.
+#
+# Without them, the following error is thrown:
+#   "attempting to grant RBAC permissions not currently held"
+#
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app httpsource-adapter
+subjects:
+- kind: ServiceAccount
+  name: knative-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app slacksource-adapter
+subjects:
+- kind: ServiceAccount
+  name: knative-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app zendesksource-adapter
+subjects:
+- kind: ServiceAccount
+  name: knative-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+
+---
+
+# Resolve sink URIs
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: knative-sources-controller-addressable-resolver
+subjects:
+- kind: ServiceAccount
+  name: knative-sources-controller
+  namespace: triggermesh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: addressable-resolver

--- a/pkg/adapter/common/controller/controller.go
+++ b/pkg/adapter/common/controller/controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,12 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testing
+// Package controller contains helpers shared between controllers embedded in
+// source adapters.
+package controller
 
-import "fmt"
+import "knative.dev/pkg/controller"
 
-// Eventf returns the attributes of an API event in the format returned by
-// Kubernetes' FakeRecorder.
-func Eventf(eventtype, reason, messageFmt string, args ...interface{}) string {
-	return fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...)
+// Opts returns a callback function that sets the controller's agent name and
+// configures the reconciler to skip status updates.
+func Opts(component string) controller.OptionsFn {
+	return func(impl *controller.Impl) controller.Options {
+		return controller.Options{
+			AgentName:         component,
+			SkipStatusUpdates: true,
+		}
+	}
 }

--- a/pkg/adapter/common/env/env.go
+++ b/pkg/adapter/common/env/env.go
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package env allows propagating runtime configurations via the environment.
+package env
+
+import (
+	"github.com/kelseyhightower/envconfig"
+	"knative.dev/eventing/pkg/adapter/v2"
+)
+
+// ConfigAccessor is a superset of adaper.EnvConfigAccessor that overrides
+// properties about certain variables.
+type ConfigAccessor interface {
+	adapter.EnvConfigAccessor
+	// Get the component name.
+	GetComponent() string
+}
+
+// Config is the minimal set of configuration parameters source adapters should support.
+type Config struct {
+	*adapter.EnvConfig
+	// Environment variable containing the namespace of the adapter.
+	Namespace string `envconfig:"NAMESPACE" required:"true"`
+	// Component is the kind of this adapter.
+	Component string `envconfig:"K_COMPONENT" required:"true"`
+}
+
+// Verify that Config implements ConfigAccessor.
+var _ ConfigAccessor = (*Config)(nil)
+
+// GetComponent implements ConfigAccessor.
+func (c *Config) GetComponent() string {
+	return c.Component
+}
+
+// ConfigConstructor is a callback function that returns a ConfigAccessor.
+type ConfigConstructor func() ConfigAccessor
+
+// MustProcessConfig populates the specified adapter.EnvConfigConstructor based
+// on environment variables.
+func MustProcessConfig(envCtor ConfigConstructor) ConfigAccessor {
+	env := envCtor()
+	envconfig.MustProcess("", env)
+	return env
+}

--- a/pkg/adapter/common/health/health.go
+++ b/pkg/adapter/common/health/health.go
@@ -1,0 +1,122 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package health contains helpers to enable HTTP health checking.
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+
+	"knative.dev/pkg/logging"
+)
+
+const healthPath = "/health"
+
+// Use a var instead of a const to allow tests to override this value.
+var healthPort uint16 = 8080
+
+const gracefulHandlerShutdown = 3 * time.Second
+
+// handler serves requests to the health endpoint. It returns a success HTTP
+// code when its value is true.
+type handler struct {
+	sync.RWMutex
+	ready bool
+}
+
+// Verify that handler implements http.Handler.
+var _ http.Handler = (*handler)(nil)
+
+// ServeHTTP implements http.Handler.
+func (h *handler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	if !h.isReady() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *handler) isReady() bool {
+	h.RLock()
+	defer h.RUnlock()
+
+	return h.ready
+}
+
+var defaultHandler handler
+
+// Start runs the default HTTP health handler.
+func Start(ctx context.Context) {
+	mux := &http.ServeMux{}
+	mux.Handle(healthPath, &defaultHandler)
+
+	server := &http.Server{
+		Addr:    fmt.Sprintf(":%d", healthPort),
+		Handler: mux,
+	}
+
+	errCh := make(chan error)
+
+	go func() {
+		errCh <- server.ListenAndServe()
+	}()
+
+	handleServerError := func(err error) {
+		if err != http.ErrServerClosed {
+			logging.FromContext(ctx).Errorw("Error during runtime of health server", zap.Error(err))
+		}
+	}
+
+	select {
+	case <-ctx.Done():
+		ctx, cancel := context.WithTimeout(context.Background(), gracefulHandlerShutdown)
+		defer cancel()
+
+		if err := server.Shutdown(ctx); err != nil {
+			logging.FromContext(ctx).Errorw("Error during shutdown of health server", zap.Error(err))
+		}
+
+		handleServerError(<-errCh)
+
+	case err := <-errCh:
+		handleServerError(err)
+	}
+}
+
+// MarkReady indicates that the application is ready to operate.
+func MarkReady() {
+	if defaultHandler.isReady() {
+		return
+	}
+
+	defaultHandler.Lock()
+	defer defaultHandler.Unlock()
+
+	// double-checked lock to ensure we don't write the value of "ready"
+	// twice if multiple goroutines called MarkReady() simultaneously.
+	if defaultHandler.ready {
+		return
+	}
+
+	defaultHandler.ready = true
+}

--- a/pkg/adapter/common/health/health_test.go
+++ b/pkg/adapter/common/health/health_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (c) 2020 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestHandler(t *testing.T) {
+	currentHealthPort := healthPort
+	defer func() {
+		// reset port and handler state for other tests, or in case
+		// this test is executed multiple times with -count
+		healthPort = currentHealthPort
+		defaultHandler = handler{}
+	}()
+
+	healthPort = getAvailablePort(t)
+	healthURL := fmt.Sprintf("http://:%d%s", healthPort, healthPath)
+
+	ctx, cancel := context.WithCancel(logtesting.TestContextWithLogger(t))
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		Start(ctx)
+		done <- struct{}{}
+	}()
+
+	// the server may need some time before it can serve the first request
+	pollURL(t, healthURL)
+
+	// not ready - expect HTTP error
+	resp, err := http.Get(healthURL)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+	resp.Body.Close()
+
+	MarkReady()
+
+	// ready - expect HTTP success
+	resp, err = http.Get(healthURL)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	resp.Body.Close()
+
+	cancel()
+	<-done
+}
+
+// getFreePort returns a TCP port that's guaranteed to be currently available
+// on the local host.
+func getAvailablePort(t *testing.T) uint16 {
+	t.Helper()
+
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatal("Failed to obtain a new Listener:", err)
+	}
+
+	defer l.Close()
+
+	return uint16(l.Addr().(*net.TCPAddr).Port)
+}
+
+// pollURL polls the given URL until a HTTP response is received.
+func pollURL(t *testing.T, url string) {
+	t.Helper()
+
+	var pollErr error
+
+	for i := 0; i < 10; i++ {
+		_, pollErr = http.Get(url)
+		if pollErr == nil {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("Health server didn't start. Last client error:", pollErr)
+}

--- a/pkg/adapter/common/router/router.go
+++ b/pkg/adapter/common/router/router.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"net/http"
+	"sync"
+)
+
+// Router routes incoming HTTP requests to the adequate handler based on their
+// URL path.
+type Router struct {
+	// map of URL path to HTTP handler
+	handlers sync.Map
+}
+
+// Check that Router implements http.Handler.
+var _ http.Handler = (*Router)(nil)
+
+// RegisterPath registers a HTTP handler for serving requests at the given URL path.
+func (r *Router) RegisterPath(urlPath string, h http.Handler) {
+	r.handlers.Store(urlPath, h)
+}
+
+// DeregisterPath de-registers the HTTP handler for the given URL path.
+func (r *Router) DeregisterPath(urlPath string) {
+	r.handlers.Delete(urlPath)
+}
+
+// ServeHTTP implements http.Handler.
+func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	h, ok := r.handlers.Load(req.URL.Path)
+	if !ok {
+		http.Error(w, "No handler for path "+req.URL.Path, http.StatusNotFound)
+		return
+	}
+
+	h.(http.Handler).ServeHTTP(w, req)
+}

--- a/pkg/adapter/common/router/router_test.go
+++ b/pkg/adapter/common/router/router_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const headerHandlerName = "HANDLER"
+
+func TestRouter(t *testing.T) {
+	r := &Router{}
+
+	// new router responds with status NotFound
+
+	resp := recordResponse(t, r, "/")
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+
+	// register 2 handlers
+
+	r.RegisterPath("/foo", responder("foo"))
+	r.RegisterPath("/bar", responder("bar"))
+
+	assert.Equal(t, []string{"/bar", "/foo"}, handlersKeys(r))
+
+	resp = recordResponse(t, r, "/foo")
+	assert.Equal(t, "foo", resp.Header().Get(headerHandlerName))
+
+	resp = recordResponse(t, r, "/bar")
+	assert.Equal(t, "bar", resp.Header().Get(headerHandlerName))
+
+	// attempt to delete unregistered paths
+
+	r.DeregisterPath("/")
+	r.DeregisterPath("/baz")
+
+	assert.Equal(t, []string{"/bar", "/foo"}, handlersKeys(r))
+
+	// delete a registered path
+
+	r.DeregisterPath("/foo")
+
+	assert.Equal(t, []string{"/bar"}, handlersKeys(r))
+
+	resp = recordResponse(t, r, "/foo")
+	assert.Equal(t, http.StatusNotFound, resp.Code)
+}
+
+// responder returns a HTTP handler that responds to requests with a header
+// containing the given handler's name.
+func responder(name string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headerHandlerName, name)
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+// handlersKeys returns the keys of all the handlers currently registered in
+// the given Router, sorted lexically.
+func handlersKeys(r *Router) []string {
+	var keys []string
+
+	r.handlers.Range(func(key, _ interface{}) bool {
+		keys = append(keys, key.(string))
+		return true
+	})
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+// recordResponse sends a HTTP request to the provided handler at the given
+// URL path and returns the recorded response.
+func recordResponse(t *testing.T, h http.Handler, urlPath string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodHead, urlPath, nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	return rr
+}

--- a/pkg/adapter/common/sharedmain/sharedmain.go
+++ b/pkg/adapter/common/sharedmain/sharedmain.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sharedmain
+
+import (
+	"knative.dev/eventing/pkg/adapter/v2"
+	"knative.dev/pkg/injection"
+	"knative.dev/pkg/signals"
+
+	"github.com/triggermesh/knative-sources/pkg/adapter/common/env"
+)
+
+type namedControllerConstructor func(component string) adapter.ControllerConstructor
+type namedAdapterConstructor func(component string) adapter.AdapterConstructor
+
+// MainWithController is a shared main tailored to multi-tenant receive-adapters.
+// It performs the following initializations:
+//  * process environment variables
+//  * enable leader election / HA
+//  * set the scope to a single namespace
+//  * inject the given controller constructor
+func MainWithController(envCtor env.ConfigConstructor,
+	cCtor namedControllerConstructor, aCtor namedAdapterConstructor) {
+
+	envAcc := env.MustProcessConfig(envCtor)
+	ns := envAcc.GetNamespace()
+	component := envAcc.GetComponent()
+
+	ctx := signals.NewContext()
+	ctx = adapter.WithHAEnabled(ctx)
+	ctx = injection.WithNamespaceScope(ctx, ns)
+	ctx = adapter.WithController(ctx, cCtor(component))
+
+	adapter.MainWithEnv(ctx, component, envAcc, aCtor(component))
+}

--- a/pkg/apis/sources/v1alpha1/common_lifecycle.go
+++ b/pkg/apis/sources/v1alpha1/common_lifecycle.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"path"
 
 	"go.uber.org/zap"
 
@@ -149,7 +150,7 @@ func (m *EventSourceStatusManager) PropagateServiceAvailability(ksvc *servingv1.
 	if m.Address == nil {
 		m.Address = &duckv1.Addressable{}
 	}
-	m.Address.URL = ksvc.Status.URL
+	m.Address.URL = ksvc.Status.URL.DeepCopy()
 
 	if ksvc.IsReady() {
 		m.ConditionSet.Manage(m).MarkTrue(ConditionDeployed)
@@ -177,4 +178,13 @@ func (m *EventSourceStatusManager) PropagateServiceAvailability(ksvc *servingv1.
 	}
 
 	m.ConditionSet.Manage(m).MarkFalse(ConditionDeployed, reason, msg)
+}
+
+// SetRoute appends the given URL path to the current source's URL.
+func (m *EventSourceStatusManager) SetRoute(urlPath string) {
+	if m.Address == nil || m.Address.URL == nil {
+		return
+	}
+
+	m.Address.URL.Path = path.Join(m.Address.URL.Path, urlPath)
 }

--- a/pkg/apis/sources/v1alpha1/interfaces.go
+++ b/pkg/apis/sources/v1alpha1/interfaces.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -45,6 +45,17 @@ type EventSource interface {
 	// AsEventSource returns a unique reference to the source suitable for
 	// use as a CloudEvent source attribute.
 	AsEventSource() string
+}
+
+// multiTenant is implemented by all multi-tenant source types.
+type multiTenant interface {
+	IsMultiTenant() bool
+}
+
+// IsMultiTenant returns whether the given source type is multi-tenant.
+func IsMultiTenant(src EventSource) bool {
+	mt, ok := src.(multiTenant)
+	return ok && mt.IsMultiTenant()
 }
 
 type sourceKey struct{}

--- a/pkg/reconciler/common/adapter.go
+++ b/pkg/reconciler/common/adapter.go
@@ -29,6 +29,7 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/ptr"
+	"knative.dev/pkg/system"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
@@ -37,15 +38,20 @@ import (
 
 const metricsPrometheusPort uint16 = 9092
 
-// AdapterName returns the adapter's name for the given source object.
-func AdapterName(src kmeta.OwnerRefable) string {
+// ComponentName returns the component name for the given source object.
+func ComponentName(src kmeta.OwnerRefable) string {
 	return strings.ToLower(src.GetGroupVersionKind().Kind)
 }
 
+// MTAdapterObjectName returns a unique name to apply to all objects related to
+// the given source's multi-tenant adapter (RBAC, Deployment/KnService, ...).
+func MTAdapterObjectName(src kmeta.OwnerRefable) string {
+	return ComponentName(src) + "-" + componentAdapter
+}
+
 // NewAdapterDeployment is a wrapper around resource.NewDeployment which
-// pre-populates attributes common to all adapter Deployments.
+// pre-populates attributes common to all adapters backed by a Deployment.
 func NewAdapterDeployment(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...resource.ObjectOption) *appsv1.Deployment {
-	app := AdapterName(src)
 	srcNs := src.GetNamespace()
 	srcName := src.GetName()
 
@@ -54,34 +60,60 @@ func NewAdapterDeployment(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...r
 		sinkURIStr = sinkURI.String()
 	}
 
-	return resource.NewDeployment(srcNs, kmeta.ChildName(app+"-", srcName),
-		append([]resource.ObjectOption{
-			resource.TerminationErrorToLogs,
+	return resource.NewDeployment(srcNs, kmeta.ChildName(ComponentName(src)+"-", srcName),
+		append(commonAdapterDeploymentOptions(src), append([]resource.ObjectOption{
 			resource.Controller(src),
 
-			resource.Label(appNameLabel, app),
 			resource.Label(appInstanceLabel, srcName),
-			resource.Label(appComponentLabel, componentAdapter),
-			resource.Label(appPartOfLabel, partOf),
-			resource.Label(appManagedByLabel, managedBy),
-
-			resource.Selector(appNameLabel, app),
 			resource.Selector(appInstanceLabel, srcName),
-			resource.PodLabel(appComponentLabel, componentAdapter),
-			resource.PodLabel(appPartOfLabel, partOf),
-			resource.PodLabel(appManagedByLabel, managedBy),
-
-			resource.ServiceAccount(AdapterRBACObjectsName(src)),
 
 			resource.EnvVar(envSink, sinkURIStr),
-		}, opts...)...,
+		}, opts...)...)...,
 	)
 }
 
+// NewMTAdapterDeployment is a wrapper around resource.NewDeployment which
+// pre-populates attributes common to all multi-tenant adapters backed by a
+// Deployment.
+func NewMTAdapterDeployment(src v1alpha1.EventSource, opts ...resource.ObjectOption) *appsv1.Deployment {
+	srcNs := src.GetNamespace()
+
+	return resource.NewDeployment(srcNs, MTAdapterObjectName(src),
+		append(commonAdapterDeploymentOptions(src), append([]resource.ObjectOption{
+			resource.EnvVar(EnvNamespace, srcNs),
+			resource.EnvVar(system.NamespaceEnvKey, srcNs), // required to enable HA
+		}, opts...)...)...,
+	)
+}
+
+// commonAdapterDeploymentOptions returns a set of ObjectOptions common to all
+// adapters backed by a Deployment.
+func commonAdapterDeploymentOptions(src v1alpha1.EventSource) []resource.ObjectOption {
+	app := ComponentName(src)
+
+	return []resource.ObjectOption{
+		resource.TerminationErrorToLogs,
+
+		resource.Label(appNameLabel, app),
+		resource.Label(appComponentLabel, componentAdapter),
+		resource.Label(appPartOfLabel, partOf),
+		resource.Label(appManagedByLabel, managedBy),
+
+		resource.Selector(appNameLabel, app),
+		resource.Selector(appComponentLabel, componentAdapter),
+		resource.PodLabel(appPartOfLabel, partOf),
+		resource.PodLabel(appManagedByLabel, managedBy),
+
+		resource.ServiceAccount(MTAdapterObjectName(src)),
+
+		resource.EnvVar(envComponent, app),
+	}
+}
+
 // NewAdapterKnService is a wrapper around resource.NewKnService which
-// pre-populates attributes common to all adapter Knative Services.
+// pre-populates attributes common to all adapters backed by a Knative Service.
 func NewAdapterKnService(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...resource.ObjectOption) *servingv1.Service {
-	app := AdapterName(src)
+	app := ComponentName(src)
 	srcNs := src.GetNamespace()
 	srcName := src.GetName()
 
@@ -91,27 +123,52 @@ func NewAdapterKnService(src v1alpha1.EventSource, sinkURI *apis.URL, opts ...re
 	}
 
 	return resource.NewKnService(srcNs, kmeta.ChildName(app+"-", srcName),
-		append([]resource.ObjectOption{
+		append(commonAdapterKnServiceOptions(src), append([]resource.ObjectOption{
 			resource.Controller(src),
 
-			resource.Label(appNameLabel, app),
 			resource.Label(appInstanceLabel, srcName),
-			resource.Label(appComponentLabel, componentAdapter),
-			resource.Label(appPartOfLabel, partOf),
-			resource.Label(appManagedByLabel, managedBy),
-
-			resource.PodLabel(appNameLabel, app),
 			resource.PodLabel(appInstanceLabel, srcName),
-			resource.PodLabel(appComponentLabel, componentAdapter),
-			resource.PodLabel(appPartOfLabel, partOf),
-			resource.PodLabel(appManagedByLabel, managedBy),
-
-			resource.ServiceAccount(AdapterRBACObjectsName(src)),
 
 			resource.EnvVar(envSink, sinkURIStr),
-			resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPort), 10)),
-		}, opts...)...,
+		}, opts...)...)...,
 	)
+}
+
+// NewMTAdapterKnService is a wrapper around resource.NewKnService which
+// pre-populates attributes common to all multi-tenant adapters backed by a
+// Knative Service.
+func NewMTAdapterKnService(src v1alpha1.EventSource, opts ...resource.ObjectOption) *servingv1.Service {
+	srcNs := src.GetNamespace()
+
+	return resource.NewKnService(srcNs, MTAdapterObjectName(src),
+		append(commonAdapterKnServiceOptions(src), append([]resource.ObjectOption{
+			resource.EnvVar(EnvNamespace, srcNs),
+			resource.EnvVar(system.NamespaceEnvKey, srcNs), // required to enable HA
+		}, opts...)...)...,
+	)
+}
+
+// commonAdapterKnServiceOptions returns a set of ObjectOptions common to all
+// adapters backed by a Knative Service.
+func commonAdapterKnServiceOptions(src v1alpha1.EventSource) []resource.ObjectOption {
+	app := ComponentName(src)
+
+	return []resource.ObjectOption{
+		resource.Label(appNameLabel, app),
+		resource.Label(appComponentLabel, componentAdapter),
+		resource.Label(appPartOfLabel, partOf),
+		resource.Label(appManagedByLabel, managedBy),
+
+		resource.PodLabel(appNameLabel, app),
+		resource.PodLabel(appComponentLabel, componentAdapter),
+		resource.PodLabel(appPartOfLabel, partOf),
+		resource.PodLabel(appManagedByLabel, managedBy),
+
+		resource.ServiceAccount(MTAdapterObjectName(src)),
+
+		resource.EnvVar(envComponent, app),
+		resource.EnvVar(envMetricsPrometheusPort, strconv.FormatUint(uint64(metricsPrometheusPort), 10)),
+	}
 }
 
 // newServiceAccount returns a ServiceAccount object with its OwnerReferences
@@ -126,9 +183,9 @@ func newServiceAccount(src v1alpha1.EventSource, owners []kmeta.OwnerRefable) *c
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       src.GetNamespace(),
-			Name:            AdapterRBACObjectsName(src),
+			Name:            MTAdapterObjectName(src),
 			OwnerReferences: ownerRefs,
-			Labels:          RBACObjectLabels(src),
+			Labels:          CommonObjectLabels(src),
 		},
 	}
 
@@ -141,16 +198,13 @@ func newRoleBinding(src v1alpha1.EventSource, owner *corev1.ServiceAccount) *rba
 	saGVK := corev1.SchemeGroupVersion.WithKind("ServiceAccount")
 
 	ns := src.GetNamespace()
-	n := AdapterRBACObjectsName(src)
+	n := MTAdapterObjectName(src)
 
-	return &rbacv1.RoleBinding{
+	rb := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: ns,
 			Name:      n,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(owner, saGVK),
-			},
-			Labels: RBACObjectLabels(src),
+			Labels:    CommonObjectLabels(src),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: crGVK.Group,
@@ -164,18 +218,26 @@ func newRoleBinding(src v1alpha1.EventSource, owner *corev1.ServiceAccount) *rba
 			Name:      n,
 		}},
 	}
+
+	OwnByServiceAccount(rb, owner)
+
+	return rb
 }
 
-// AdapterRBACObjectsName returns a unique name to apply to all RBAC objects
-// for the given source's adapter.
-func AdapterRBACObjectsName(src kmeta.OwnerRefable) string {
-	return AdapterName(src) + "-" + componentAdapter
+// OwnByServiceAccount sets the owner of obj to the given ServiceAccount.
+func OwnByServiceAccount(obj metav1.Object, owner *corev1.ServiceAccount) {
+	saGVK := corev1.SchemeGroupVersion.WithKind("ServiceAccount")
+
+	obj.SetOwnerReferences([]metav1.OwnerReference{
+		*metav1.NewControllerRef(owner, saGVK),
+	})
 }
 
-// RBACObjectLabels returns a set of labels to be applied to reconciled RBAC objects.
-func RBACObjectLabels(src kmeta.OwnerRefable) labels.Set {
+// CommonObjectLabels returns a set of labels which are always applied to
+// objects reconciled for the given source type.
+func CommonObjectLabels(src kmeta.OwnerRefable) labels.Set {
 	return labels.Set{
-		appNameLabel:      AdapterName(src),
+		appNameLabel:      ComponentName(src),
 		appComponentLabel: componentAdapter,
 		appPartOfLabel:    partOf,
 		appManagedByLabel: managedBy,

--- a/pkg/reconciler/common/base.go
+++ b/pkg/reconciler/common/base.go
@@ -19,6 +19,10 @@ package common
 import (
 	"context"
 
+	"go.uber.org/zap"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	appsclientv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -34,6 +38,7 @@ import (
 	sainformerv1 "knative.dev/pkg/client/injection/kube/informers/core/v1/serviceaccount"
 	rbinformerv1 "knative.dev/pkg/client/injection/kube/informers/rbac/v1/rolebinding"
 	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/pkg/resolver"
 	servingclientv1 "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 	servingclient "knative.dev/serving/pkg/client/injection/client"
@@ -90,7 +95,7 @@ func NewGenericDeploymentReconciler(ctx context.Context, gvk schema.GroupVersion
 		Client:                k8sclient.Get(ctx).AppsV1().Deployments,
 		PodClient:             k8sclient.Get(ctx).CoreV1().Pods,
 		Lister:                informer.Lister().Deployments,
-		GenericRBACReconciler: NewGenericRbacReconciler(ctx),
+		GenericRBACReconciler: NewGenericRBACReconciler(ctx),
 	}
 
 	informer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
@@ -108,29 +113,98 @@ func NewGenericServiceReconciler(ctx context.Context, gvk schema.GroupVersionKin
 	adapterHandlerFn func(obj interface{}),
 ) GenericServiceReconciler {
 
-	informer := serviceinformerv1.Get(ctx)
-
-	r := GenericServiceReconciler{
-		SinkResolver:          resolver.NewURIResolver(ctx, resolverCallback),
-		Client:                servingclient.Get(ctx).ServingV1().Services,
-		Lister:                informer.Lister().Services,
-		GenericRBACReconciler: NewGenericRbacReconciler(ctx),
-	}
-
-	informer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	serviceinformerv1.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterControllerGVK(gvk),
 		Handler:    controller.HandleAll(adapterHandlerFn),
 	})
 
-	return r
+	return newGenericServiceReconciler(ctx, resolverCallback)
 }
 
-// NewGenericRbacReconciler creates a new GenericRbacReconciler.
-func NewGenericRbacReconciler(ctx context.Context) *GenericRBACReconciler {
+// NewMTGenericServiceReconciler creates a new GenericServiceReconciler for a
+// multi-tenant adapter and attaches a default event handler to its Service
+// informer.
+func NewMTGenericServiceReconciler(ctx context.Context, typ kmeta.OwnerRefable,
+	resolverCallback func(types.NamespacedName),
+	adapterHandlerFn func(obj interface{}),
+) GenericServiceReconciler {
+
+	serviceinformerv1.Get(ctx).Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: hasAdapterLabelsForType(typ),
+		Handler:    controller.HandleAll(adapterHandlerFn),
+	})
+
+	return newGenericServiceReconciler(ctx, resolverCallback)
+}
+
+// NewGenericRBACReconciler creates a new GenericRBACReconciler.
+func NewGenericRBACReconciler(ctx context.Context) *GenericRBACReconciler {
 	return &GenericRBACReconciler{
 		SAClient: k8sclient.Get(ctx).CoreV1().ServiceAccounts,
 		RBClient: k8sclient.Get(ctx).RbacV1().RoleBindings,
 		SALister: sainformerv1.Get(ctx).Lister().ServiceAccounts,
 		RBLister: rbinformerv1.Get(ctx).Lister().RoleBindings,
+	}
+}
+
+// newMTGenericServiceReconciler creates a new GenericServiceReconciler.
+func newGenericServiceReconciler(ctx context.Context,
+	resolverCallback func(types.NamespacedName),
+) GenericServiceReconciler {
+
+	return GenericServiceReconciler{
+		SinkResolver:          resolver.NewURIResolver(ctx, resolverCallback),
+		Client:                servingclient.Get(ctx).ServingV1().Services,
+		Lister:                serviceinformerv1.Get(ctx).Lister().Services,
+		GenericRBACReconciler: NewGenericRBACReconciler(ctx),
+	}
+
+}
+
+// filteredGlobalResyncFunc is a function that enqueues all objects from the
+// given informer that pass the provided filter function.
+type filteredGlobalResyncFunc func(func(interface{}) bool, cache.SharedInformer)
+
+// objectFilterFunc is a filtering function for filteredGlobalResyncFunc.
+type objectFilterFunc func(interface{}) bool
+
+// hasAdapterLabelsForType returns a function that filters based on standard
+// labels applied to all adapters of the given source type.
+func hasAdapterLabelsForType(typ kmeta.OwnerRefable) objectFilterFunc {
+	return func(obj interface{}) bool {
+		object, ok := obj.(metav1.Object)
+		if !ok {
+			return false
+		}
+
+		ls := CommonObjectLabels(typ).AsSelectorPreValidated()
+		return ls.Matches(labels.Set(object.GetLabels()))
+	}
+}
+
+// isInNamespace returns a function that filters all objects which are not in
+// the given namespace.
+func isInNamespace(ns string) objectFilterFunc {
+	return func(obj interface{}) bool {
+		object := obj.(metav1.Object)
+		return object.GetNamespace() == ns
+	}
+}
+
+// EnqueueObjectsInNamespaceOf accepts an object and triggers a global resync
+// of all objects in the given informer matching that object's namespace.
+// Intended to be used to resync source objects when the state of their
+// (common) multi-tenant adapter changes.
+func EnqueueObjectsInNamespaceOf(inf cache.SharedInformer, resyncFn filteredGlobalResyncFunc,
+	logger *zap.SugaredLogger) func(interface{}) {
+
+	return func(obj interface{}) {
+		adapter, err := kmeta.DeletionHandlingAccessor(obj)
+		if err != nil {
+			logger.Error(err)
+			return
+		}
+
+		resyncFn(isInNamespace(adapter.GetNamespace()), inf)
 	}
 }

--- a/pkg/reconciler/common/base_test.go
+++ b/pkg/reconciler/common/base_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright (c) 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/kmeta"
+	logtesting "knative.dev/pkg/logging/testing"
+)
+
+func TestEnqueueObjectsInNamespaceOf(t *testing.T) {
+	const ns1, ns2 = "ns1", "ns2"
+
+	storedObjects := []interface{}{
+		newFakeObject(ns1, "foo"),
+		newFakeObject(ns1, "bar"),
+		newFakeObject(ns1, "baz"),
+		newFakeObject(ns2, "qux"),
+	}
+
+	inf := &fakeInformer{
+		store: storedObjects,
+	}
+
+	impl := controller.NewImplFull(nil, controller.ControllerOptions{
+		Logger: logtesting.TestLogger(t),
+	})
+	t.Cleanup(impl.WorkQueue().ShutDown)
+
+	handlerFn := EnqueueObjectsInNamespaceOf(inf, impl.FilteredGlobalResync, nil)
+
+	// handling an object in ns1 should enqueue foo,bar,baz but not qux
+	handlerFn(
+		newFakeObject(ns1, "fake-adapter"),
+	)
+
+	// account for filtering/processing latency
+	time.Sleep(10 * time.Millisecond)
+
+	expectEnqueued := []string{"ns1/foo", "ns1/bar", "ns1/baz"}
+
+	require.Equal(t, len(expectEnqueued), impl.WorkQueue().Len(), "Unexpected queue length")
+
+	enqueued := popKeys(len(expectEnqueued), impl.WorkQueue())
+	assert.ElementsMatch(t, expectEnqueued, enqueued)
+}
+
+func TestHasAdapterLabelsForType(t *testing.T) {
+	typ := &fakeObject{}
+	filterFn := hasAdapterLabelsForType(&fakeObject{})
+
+	t.Run("matches common selector", func(t *testing.T) {
+		objAllLabels := &fakeObject{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					appNameLabel:      ComponentName(typ),
+					appComponentLabel: componentAdapter,
+					appPartOfLabel:    partOf,
+					appManagedByLabel: managedBy,
+					"extra":           "label",
+				},
+			},
+		}
+
+		assert.True(t, filterFn(objAllLabels), "Expected to match common set of labels")
+	})
+
+	t.Run("doesn't match common selector", func(t *testing.T) {
+		objMissingLabels := &fakeObject{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					appPartOfLabel:    partOf,
+					appManagedByLabel: managedBy,
+				},
+			},
+		}
+
+		assert.False(t, filterFn(objMissingLabels), "Expected not to match common set of labels")
+	})
+}
+
+// popKeys pops n items from a queue and returns their keys.
+func popKeys(n int, q workqueue.RateLimitingInterface) []string {
+	enqueuedObjs := make([]string, n)
+
+	for i := range enqueuedObjs {
+		obj, _ := q.Get()
+		enqueuedObjs[i] = obj.(types.NamespacedName).String()
+	}
+
+	return enqueuedObjs
+}
+
+// fakeObject implements kmeta.Accessor and kmeta.OwnerRefable for tests.
+type fakeObject struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	runtime.Object
+}
+
+var (
+	_ kmeta.Accessor     = (*fakeObject)(nil)
+	_ kmeta.OwnerRefable = (*fakeObject)(nil)
+)
+
+// disambiguate GetObjectKind method contained in by both runtime.Object and metav1.TypeMeta.
+func (*fakeObject) GetObjectKind() schema.ObjectKind { return nil }
+
+// GetGroupVersionKind implements kmeta.OwnerRefable.
+func (*fakeObject) GetGroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{
+		Kind: "Fake",
+	}
+}
+
+// newFakeObject creates a fake API object with the given namespace and name.
+func newFakeObject(ns, name string) metav1.Object {
+	return &fakeObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+		},
+	}
+}
+
+// fakeInformer mocks a cache.SharedInformer.
+type fakeInformer struct {
+	store fakeStore
+}
+
+// GetStore implements cache.SharedInformer.
+func (i *fakeInformer) GetStore() cache.Store {
+	return i.store
+}
+
+// fakeStore mocks a cache.Store.
+type fakeStore []interface{}
+
+// List implements cache.Store.
+func (s fakeStore) List() []interface{} {
+	return s
+}
+
+/* unimplemented in those tests */
+
+func (*fakeInformer) AddEventHandler(cache.ResourceEventHandler) {}
+
+func (*fakeInformer) AddEventHandlerWithResyncPeriod(cache.ResourceEventHandler, time.Duration) {}
+
+func (*fakeInformer) GetController() cache.Controller { return nil }
+
+func (*fakeInformer) Run(<-chan struct{}) {}
+
+func (*fakeInformer) HasSynced() bool { return true }
+
+func (*fakeInformer) LastSyncResourceVersion() string { return "" }
+
+func (fakeStore) Add(interface{}) error { return nil }
+
+func (fakeStore) Update(interface{}) error { return nil }
+
+func (fakeStore) Delete(interface{}) error { return nil }
+
+func (fakeStore) ListKeys() []string { return nil }
+
+func (fakeStore) Get(interface{}) (interface{}, bool, error) { return nil, false, nil }
+
+func (fakeStore) GetByKey(string) (interface{}, bool, error) { return nil, false, nil }
+
+func (fakeStore) Replace([]interface{}, string) error { return nil }
+
+func (fakeStore) Resync() error { return nil }

--- a/pkg/reconciler/common/doc.go
+++ b/pkg/reconciler/common/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package common contains reconciliation helpers shared by source reconcilers.
+// Package common contains reconciliation helpers shared between source reconcilers.
 package common

--- a/pkg/reconciler/common/event/event_test.go
+++ b/pkg/reconciler/common/event/event_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import (
 	"knative.dev/pkg/controller"
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
-	eventtesting "github.com/triggermesh/knative-sources/pkg/reconciler/common/event/testing"
+	eventtesting "github.com/triggermesh/knative-sources/pkg/testing/event"
 )
 
 func TestEvents(t *testing.T) {

--- a/pkg/reconciler/common/reconcile.go
+++ b/pkg/reconciler/common/reconcile.go
@@ -39,6 +39,7 @@ import (
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common/event"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common/semantic"
+	"github.com/triggermesh/knative-sources/pkg/routing"
 )
 
 // List of annotations set on Knative Serving objects by the Knative Serving
@@ -114,9 +115,17 @@ func (r *GenericDeploymentReconciler) reconcileAdapter(ctx context.Context,
 
 	src := v1alpha1.SourceFromContext(ctx)
 
-	if err := r.reconcileRBAC(ctx, rbacOwners); err != nil {
+	sa, err := r.reconcileRBAC(ctx, rbacOwners)
+	if err != nil {
 		src.GetStatusManager().MarkRBACNotBound()
 		return fmt.Errorf("reconciling RBAC objects: %w", err)
+	}
+
+	if v1alpha1.IsMultiTenant(src) {
+		// delegate ownership to the ServiceAccount in order to cause a
+		// garbage collection once all instances of the given source
+		// type have been deleted from the namespace
+		OwnByServiceAccount(desiredAdapter, sa)
 	}
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
@@ -139,7 +148,7 @@ func (r *GenericDeploymentReconciler) reconcileAdapter(ctx context.Context,
 func (r *GenericDeploymentReconciler) getOrCreateAdapter(ctx context.Context, desiredAdapter *appsv1.Deployment) (*appsv1.Deployment, error) {
 	src := v1alpha1.SourceFromContext(ctx)
 
-	adapter, err := r.FindAdapter(src)
+	adapter, err := findAdapter(r, src, metav1.GetControllerOfNoCopy(desiredAdapter))
 	switch {
 	case apierrors.IsNotFound(err):
 		adapter, err = r.Client(src.GetNamespace()).Create(ctx, desiredAdapter, metav1.CreateOptions{})
@@ -147,22 +156,13 @@ func (r *GenericDeploymentReconciler) getOrCreateAdapter(ctx context.Context, de
 			return nil, reconciler.NewEvent(corev1.EventTypeWarning, ReasonFailedAdapterCreate,
 				"Failed to create adapter Deployment %q: %s", desiredAdapter.Name, err)
 		}
-		event.Normal(ctx, ReasonAdapterCreate, "Created adapter Deployment %q", adapter.Name)
+		event.Normal(ctx, ReasonAdapterCreate, "Created adapter Deployment %q", adapter.GetName())
 
 	case err != nil:
 		return nil, fmt.Errorf("failed to get adapter Deployment from cache: %w", err)
 	}
 
-	return adapter, nil
-}
-
-// FindAdapter returns the adapter Deployment for a given source if it exists.
-func (r *GenericDeploymentReconciler) FindAdapter(src v1alpha1.EventSource) (*appsv1.Deployment, error) {
-	o, err := findAdapter(r, src)
-	if err != nil {
-		return nil, err
-	}
-	return o.(*appsv1.Deployment), nil
+	return adapter.(*appsv1.Deployment), nil
 }
 
 // syncAdapterDeployment synchronizes the desired state of an adapter Deployment
@@ -237,9 +237,19 @@ func (r *GenericServiceReconciler) reconcileAdapter(ctx context.Context,
 
 	src := v1alpha1.SourceFromContext(ctx)
 
-	if err := r.reconcileRBAC(ctx, rbacOwners); err != nil {
+	isMultiTenant := v1alpha1.IsMultiTenant(src)
+
+	sa, err := r.reconcileRBAC(ctx, rbacOwners)
+	if err != nil {
 		src.GetStatusManager().MarkRBACNotBound()
 		return fmt.Errorf("reconciling RBAC objects: %w", err)
+	}
+
+	if isMultiTenant {
+		// delegate ownership to the ServiceAccount in order to cause a
+		// garbage collection once all instances of the given source
+		// type have been deleted from the namespace
+		OwnByServiceAccount(desiredAdapter, sa)
 	}
 
 	currentAdapter, err := r.getOrCreateAdapter(ctx, desiredAdapter)
@@ -252,7 +262,11 @@ func (r *GenericServiceReconciler) reconcileAdapter(ctx context.Context,
 	if err != nil {
 		return fmt.Errorf("failed to synchronize adapter Service: %w", err)
 	}
+
 	src.GetStatusManager().PropagateServiceAvailability(currentAdapter)
+	if isMultiTenant {
+		src.GetStatusManager().SetRoute(routing.URLPath(src))
+	}
 
 	return nil
 }
@@ -262,7 +276,7 @@ func (r *GenericServiceReconciler) reconcileAdapter(ctx context.Context,
 func (r *GenericServiceReconciler) getOrCreateAdapter(ctx context.Context, desiredAdapter *servingv1.Service) (*servingv1.Service, error) {
 	src := v1alpha1.SourceFromContext(ctx)
 
-	adapter, err := r.FindAdapter(src)
+	adapter, err := findAdapter(r, src, metav1.GetControllerOfNoCopy(desiredAdapter))
 	switch {
 	case apierrors.IsNotFound(err):
 		adapter, err = r.Client(src.GetNamespace()).Create(ctx, desiredAdapter, metav1.CreateOptions{})
@@ -270,22 +284,13 @@ func (r *GenericServiceReconciler) getOrCreateAdapter(ctx context.Context, desir
 			return nil, reconciler.NewEvent(corev1.EventTypeWarning, ReasonFailedAdapterCreate,
 				"Failed to create adapter Service %q: %s", desiredAdapter.Name, err)
 		}
-		event.Normal(ctx, ReasonAdapterCreate, "Created adapter Service %q", adapter.Name)
+		event.Normal(ctx, ReasonAdapterCreate, "Created adapter Service %q", adapter.GetName())
 
 	case err != nil:
 		return nil, fmt.Errorf("failed to get adapter Service from cache: %w", err)
 	}
 
-	return adapter, nil
-}
-
-// FindAdapter returns the adapter Service for a given source if it exists.
-func (r *GenericServiceReconciler) FindAdapter(src v1alpha1.EventSource) (*servingv1.Service, error) {
-	o, err := findAdapter(r, src)
-	if err != nil {
-		return nil, err
-	}
-	return o.(*servingv1.Service), nil
+	return adapter.(*servingv1.Service), nil
 }
 
 // syncAdapterService synchronizes the desired state of an adapter Service
@@ -322,13 +327,18 @@ func (r *GenericServiceReconciler) syncAdapterService(ctx context.Context,
 }
 
 // findAdapter returns the adapter object for a given source if it exists.
-func findAdapter(genericReconciler interface{}, src v1alpha1.EventSource) (metav1.Object, error) {
-	// the combination of standard labels {name,instance} is unique and
-	// immutable
-	sel := labels.SelectorFromSet(labels.Set{
-		appNameLabel:     AdapterName(src),
-		appInstanceLabel: src.GetName(),
-	})
+func findAdapter(genericReconciler interface{},
+	src v1alpha1.EventSource, owner *metav1.OwnerReference) (metav1.Object, error) {
+
+	ls := CommonObjectLabels(src)
+
+	if !v1alpha1.IsMultiTenant(src) {
+		// the combination of standard labels {name,instance} is unique
+		// and immutable for single-tenant sources
+		ls[appInstanceLabel] = src.GetName()
+	}
+
+	sel := labels.SelectorFromValidatedSet(ls)
 
 	var objs []metav1.Object
 	var gr schema.GroupResource
@@ -360,7 +370,9 @@ func findAdapter(genericReconciler interface{}, src v1alpha1.EventSource) (metav
 	}
 
 	for _, obj := range objs {
-		if metav1.IsControlledBy(obj, src) {
+		objOwner := metav1.GetControllerOfNoCopy(obj)
+
+		if objOwner.UID == owner.UID {
 			return obj, nil
 		}
 	}
@@ -378,13 +390,15 @@ func newNotFoundForSelector(gr schema.GroupResource, sel labels.Selector) *apier
 }
 
 // reconcileRBAC wraps the reconciliation logic for RBAC objects.
-func (r *GenericRBACReconciler) reconcileRBAC(ctx context.Context, owners []kmeta.OwnerRefable) error {
+func (r *GenericRBACReconciler) reconcileRBAC(ctx context.Context,
+	owners []kmeta.OwnerRefable) (*corev1.ServiceAccount, error) {
+
 	// The ServiceAccount's ownership is shared between all instances of a
 	// given source type. It gets garbage collected by Kubernetes as soon
 	// as its last owner (source) is deleted, so we don't need to clean
 	// things up explicitly once the last source gets deleted.
 	if len(owners) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	src := v1alpha1.SourceFromContext(ctx)
@@ -392,24 +406,24 @@ func (r *GenericRBACReconciler) reconcileRBAC(ctx context.Context, owners []kmet
 	desiredSA := newServiceAccount(src, owners)
 	currentSA, err := r.getOrCreateAdapterServiceAccount(ctx, desiredSA)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	desiredRB := newRoleBinding(src, currentSA)
 	currentRB, err := r.getOrCreateAdapterRoleBinding(ctx, desiredRB)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, err = r.syncAdapterServiceAccount(ctx, currentSA, desiredSA); err != nil {
-		return fmt.Errorf("synchronizing adapter ServiceAccount: %w", err)
+	if currentSA, err = r.syncAdapterServiceAccount(ctx, currentSA, desiredSA); err != nil {
+		return nil, fmt.Errorf("synchronizing adapter ServiceAccount: %w", err)
 	}
 
 	if _, err = r.syncAdapterRoleBinding(ctx, currentRB, desiredRB); err != nil {
-		return fmt.Errorf("synchronizing adapter RoleBinding: %w", err)
+		return nil, fmt.Errorf("synchronizing adapter RoleBinding: %w", err)
 	}
 
-	return nil
+	return currentSA, nil
 }
 
 // getOrCreateAdapterServiceAccount returns the existing adapter ServiceAccount

--- a/pkg/reconciler/httpsource/controller.go
+++ b/pkg/reconciler/httpsource/controller.go
@@ -39,7 +39,7 @@ func NewController(
 ) *controller.Impl {
 
 	typ := (*v1alpha1.HTTPSource)(nil)
-	app := common.AdapterName(typ)
+	app := common.ComponentName(typ)
 
 	adapterCfg := &adapterConfig{
 		configs: source.WatchConfigurations(ctx, app, cmw, source.WithLogging, source.WithMetrics),

--- a/pkg/reconciler/slacksource/controller.go
+++ b/pkg/reconciler/slacksource/controller.go
@@ -38,7 +38,7 @@ func NewController(
 ) *controller.Impl {
 
 	typ := (*v1alpha1.SlackSource)(nil)
-	app := common.AdapterName(typ)
+	app := common.ComponentName(typ)
 
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.

--- a/pkg/reconciler/testing/controller.go
+++ b/pkg/reconciler/testing/controller.go
@@ -26,6 +26,8 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
 	rt "knative.dev/pkg/reconciler/testing"
+
+	"github.com/triggermesh/knative-sources/pkg/testing/structs"
 )
 
 // TestControllerConstructor tests that a controller constructor meets our requirements.
@@ -56,7 +58,7 @@ func TestControllerConstructor(t *testing.T, ctor injection.ControllerConstructo
 	ctrler := ctor(ctx, cmw)
 
 	// catch unitialized fields in Reconciler struct
-	EnsureNoNilField(t, ctrler)
+	structs.EnsureNoNilField(t, ctrler)
 }
 
 // TestControllerConstructorFailures tests that a controller constructor fails

--- a/pkg/reconciler/testing/factory.go
+++ b/pkg/reconciler/testing/factory.go
@@ -59,7 +59,7 @@ func MakeFactory(ctor Ctor) rt.Factory {
 		ctx = logging.WithLogger(ctx, logtesting.TestLogger(t))
 
 		// the controller.Reconciler uses an internal client to handle
-		// target objects
+		// source objects
 		ctx, client := fakeinjectionclient.With(ctx, ls.GetSourcesObjects()...)
 
 		// all clients used inside reconciler implementations should be

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -46,7 +46,7 @@ var clientSetSchemes = []func(*runtime.Scheme) error{
 	fakeservingclient.AddToScheme,
 	// although our reconcilers do not handle eventing objects directly, we
 	// do need to register the eventing Scheme so that sink URI resolvers
-	// can recongnize the Broker objects we use in tests
+	// can recognize the Broker objects we use in tests
 	fakeeventingclientset.AddToScheme,
 }
 

--- a/pkg/reconciler/testing/reconcile.go
+++ b/pkg/reconciler/testing/reconcile.go
@@ -43,8 +43,9 @@ import (
 
 	"github.com/triggermesh/knative-sources/pkg/apis/sources/v1alpha1"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common"
-	eventtesting "github.com/triggermesh/knative-sources/pkg/reconciler/common/event/testing"
 	"github.com/triggermesh/knative-sources/pkg/reconciler/common/skip"
+	"github.com/triggermesh/knative-sources/pkg/routing"
+	eventtesting "github.com/triggermesh/knative-sources/pkg/testing/event"
 )
 
 const (
@@ -387,6 +388,10 @@ func propagateAdapterAvailabilityFunc(adapter runtime.Object) func(src v1alpha1.
 			src.GetStatusManager().PropagateDeploymentAvailability(context.Background(), a, nil)
 		case *servingv1.Service:
 			src.GetStatusManager().PropagateServiceAvailability(a)
+
+			if v1alpha1.IsMultiTenant(src) {
+				src.GetStatusManager().SetRoute(routing.URLPath(src))
+			}
 		}
 	}
 }
@@ -417,6 +422,13 @@ func adapterCtor(adapterBuilder interface{}, src v1alpha1.EventSource) adapterCt
 			obj = typedAdapterBuilder.BuildAdapter(src, tSinkURI)
 		case common.AdapterServiceBuilder:
 			obj = typedAdapterBuilder.BuildAdapter(src, tSinkURI)
+		}
+
+		// emulate the logic applied by the generic reconciler, which
+		// automatically sets the ServiceAccount as owner of
+		// multi-tenant adapters
+		if v1alpha1.IsMultiTenant(src) {
+			common.OwnByServiceAccount(obj.(metav1.Object), NewServiceAccount(src)())
 		}
 
 		for _, opt := range opts {
@@ -497,8 +509,8 @@ func newAdressable() *eventingv1.Broker {
 /* RBAC */
 
 func NewServiceAccount(src kmeta.OwnerRefable) func() *corev1.ServiceAccount {
-	name := common.AdapterName(src) + "-adapter"
-	labels := common.RBACObjectLabels(src)
+	name := common.ComponentName(src) + "-adapter"
+	labels := common.CommonObjectLabels(src)
 
 	return func() *corev1.ServiceAccount {
 		sa := &corev1.ServiceAccount{
@@ -554,15 +566,15 @@ func NewRoleBinding(sa *corev1.ServiceAccount) func() *rbacv1.RoleBinding {
 
 /* Events */
 
-func createServiceAccountEvent(src kmeta.OwnerRefable) string {
+func createServiceAccountEvent(src v1alpha1.EventSource) string {
 	return eventtesting.Eventf(corev1.EventTypeNormal, common.ReasonRBACCreate,
 		"Created ServiceAccount %q due to the creation of a %s object",
-		common.AdapterRBACObjectsName(src), src.GetGroupVersionKind().Kind)
+		common.MTAdapterObjectName(src), src.GetGroupVersionKind().Kind)
 }
-func createRoleBindingEvent(src kmeta.OwnerRefable) string {
+func createRoleBindingEvent(src v1alpha1.EventSource) string {
 	return eventtesting.Eventf(corev1.EventTypeNormal, common.ReasonRBACCreate,
 		"Created RoleBinding %q due to the creation of a %s object",
-		common.AdapterRBACObjectsName(src), src.GetGroupVersionKind().Kind)
+		common.MTAdapterObjectName(src), src.GetGroupVersionKind().Kind)
 }
 func createAdapterEvent(name, kind string) string {
 	return eventtesting.Eventf(corev1.EventTypeNormal, common.ReasonAdapterCreate, "Created adapter %s %q", kind, name)

--- a/pkg/reconciler/testing/utils.go
+++ b/pkg/reconciler/testing/utils.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020 TriggerMesh Inc.
+Copyright (c) 2020-2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,35 +18,11 @@ package testing
 
 import (
 	"os"
-	"reflect"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"knative.dev/pkg/controller"
 )
-
-// EnsureNoNilField fails the test if the provided Impl's reconciler contains
-// nil pointers or interfaces.
-func EnsureNoNilField(t *testing.T, impl *controller.Impl) {
-	t.Helper()
-
-	recVal := reflect.ValueOf(impl.Reconciler).Elem().
-		FieldByName("reconciler"). // knative.dev/pkg/controller.Reconciler
-		Elem().                    // injection/reconciler/sources/v1alpha1/<type>.Interface
-		Elem()                     //*reconciler.Reconciler
-
-	for i := 0; i < recVal.NumField(); i++ {
-		f := recVal.Field(i)
-		switch f.Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Func:
-			if f.IsNil() {
-				t.Errorf("struct field %q is nil", recVal.Type().Field(i).Name)
-			}
-		}
-	}
-}
 
 // SetEnvVar sets the value of an env var and returns a function that can be
 // deferred to unset that variable.

--- a/pkg/reconciler/zendesksource/controller.go
+++ b/pkg/reconciler/zendesksource/controller.go
@@ -44,7 +44,7 @@ func NewController(
 ) *controller.Impl {
 
 	typ := (*v1alpha1.ZendeskSource)(nil)
-	app := common.AdapterName(typ)
+	app := common.ComponentName(typ)
 
 	// Calling envconfig.Process() with a prefix appends that prefix
 	// (uppercased) to the Go field name, e.g. MYSOURCE_IMAGE.

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,14 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package routing
 
-// Common environment variables propagated to adapters.
-const (
-	EnvName      = "NAME"
-	EnvNamespace = "NAMESPACE"
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	envSink                  = "K_SINK"
-	envComponent             = "K_COMPONENT"
-	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
-)
+// URLPath returns a URL path to route requests for the given source object.
+func URLPath(src metav1.Object) string {
+	return "/" + src.GetNamespace() + "/" + src.GetName()
+}

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020-2021 TriggerMesh Inc.
+Copyright (c) 2021 TriggerMesh Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,14 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+package routing
 
-// Common environment variables propagated to adapters.
-const (
-	EnvName      = "NAME"
-	EnvNamespace = "NAMESPACE"
+import (
+	"testing"
 
-	envSink                  = "K_SINK"
-	envComponent             = "K_COMPONENT"
-	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestURLPath(t *testing.T) {
+	obj := &struct {
+		metav1.ObjectMeta
+	}{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "testname",
+		},
+	}
+
+	assert.Equal(t, URLPath(obj), "/testns/testname")
+}

--- a/pkg/testing/event/event.go
+++ b/pkg/testing/event/event.go
@@ -14,14 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package common
+// Package event contains test helpers for Kubernetes API events.
+package event
 
-// Common environment variables propagated to adapters.
-const (
-	EnvName      = "NAME"
-	EnvNamespace = "NAMESPACE"
+import "fmt"
 
-	envSink                  = "K_SINK"
-	envComponent             = "K_COMPONENT"
-	envMetricsPrometheusPort = "METRICS_PROMETHEUS_PORT"
-)
+// Eventf returns the attributes of an API event in the format returned by
+// Kubernetes' FakeRecorder.
+func Eventf(eventtype, reason, messageFmt string, args ...interface{}) string {
+	return fmt.Sprintf(eventtype+" "+reason+" "+messageFmt, args...)
+}

--- a/pkg/testing/structs/structs.go
+++ b/pkg/testing/structs/structs.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) 2020-2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package structs provides helpers to test Go structs.
+package structs
+
+import (
+	"reflect"
+	"testing"
+
+	"knative.dev/pkg/controller"
+)
+
+// EnsureNoNilField fails the test if the provided Impl's reconciler contains
+// nil pointers or interfaces.
+func EnsureNoNilField(t *testing.T, impl *controller.Impl) {
+	t.Helper()
+
+	recVal := reflect.ValueOf(impl.Reconciler).
+		Elem().                    // injection/reconciler/sources/v1alpha1/<type>.reconcilerImpl
+		FieldByName("reconciler"). // injection/reconciler/sources/v1alpha1/<type>.Interface
+		Elem().                    // *pkg/reconciler/<type>.Reconciler (ptr)
+		Elem()                     //  pkg/reconciler/<type>.Reconciler (val)
+
+	for i := 0; i < recVal.NumField(); i++ {
+		f := recVal.Field(i)
+		switch f.Kind() {
+		case reflect.Interface, reflect.Ptr, reflect.Func:
+			if f.IsNil() {
+				t.Errorf("struct field %q is nil", recVal.Type().Field(i).Name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Plain copy from `triggermesh/aws-event-sources` to keep things in sync.

Turning existing single-tenant sources into multi-tenant sources in off-scope for this PR.