### PR TITLE
Remove appId check as it blocks validation

### DIFF
--- a/pkg/adapter/slacksource/slack.go
+++ b/pkg/adapter/slacksource/slack.go
@@ -124,12 +124,6 @@ func (h *slackEventAPIHandler) handleAll(w http.ResponseWriter, r *http.Request)
 	// Otherwise the message will be retried.
 	// See: https://api.slack.com/events-api#receiving_events (Responding to Events)
 
-	if h.appID != "" && event.APIAppID != h.appID {
-		// silently ignore, some other integration should take
-		// care of this event.
-		return
-	}
-
 	// There are only 2 documented types to be received from the Events API
 	// - `event_callback`, See: https://api.slack.com/events-api#receiving_events
 	// - `event_callback`, See: https://api.slack.com/events-api#subscriptions

--- a/pkg/adapter/slacksource/slack.go
+++ b/pkg/adapter/slacksource/slack.go
@@ -119,19 +119,25 @@ func (h *slackEventAPIHandler) handleAll(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// All paths that are not managed by this integration and are
-	// not errors need to return 2xx withing 3 seconds to Slack API.
-	// Otherwise the message will be retried.
-	// See: https://api.slack.com/events-api#receiving_events (Responding to Events)
-
 	// There are only 2 documented types to be received from the Events API
 	// - `event_callback`, See: https://api.slack.com/events-api#receiving_events
 	// - `event_callback`, See: https://api.slack.com/events-api#subscriptions
 	switch event.Type {
 	case "event_callback":
+		// All paths that are not managed by this integration and are
+		// not errors need to return 2xx withing 3 seconds to Slack API.
+		// Otherwise the message will be retried.
+		// See: https://api.slack.com/events-api#receiving_events (Responding to Events)
+		if h.appID != "" && event.APIAppID != h.appID {
+			return
+		}
+
 		h.handleCallback(event, w)
 
 	case "url_verification":
+		// url_verification does not include an appID so there is no way to
+		// filter against it
+
 		h.handleChallenge(body, w)
 
 	default:


### PR DESCRIPTION
Bumped into this with a customer where they were attempting to register the slack source webhook using the url_validation, and Slack refused to accept it because there was no AppId associated with the event packet.