### PR TITLE
Validate subdomain format in CRD

### DIFF
--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -53,7 +53,7 @@ spec:
               subdomain:
                 description: Name of the Zendesk subdomain.
                 type: string
-                minLength: 1
+                pattern: ^[a-z0-9][a-z0-9-]+[a-z0-9]$
               email:
                 description: Email of the Zendesk user to authenticate as.
                 type: string


### PR DESCRIPTION
A Zendesk subdomain must
* be a valid [rfc1123](https://tools.ietf.org/html/rfc1123) subdomain (alphanumeric characters and dashes, start and end with alphanumeric  character)
* contain at least 3 characters

Fixes an issue where a user could pass an invalid `spec.subdomain` and prevent the object from being finalized.