### PR TITLE
Disallow empty name/key in valueFromSecret refs

### DIFF
--- a/config/300-httppollersource.yaml
+++ b/config/300-httppollersource.yaml
@@ -84,6 +84,9 @@ spec:
                       key:
                         description: Key from the Secret object.
                         type: string
+                    required:
+                    - name
+                    - key
                 oneOf:
                 - required: ['value']
                 - required: ['valueFromSecret']

--- a/config/300-slacksource.yaml
+++ b/config/300-slacksource.yaml
@@ -67,6 +67,9 @@ spec:
                       key:
                         description: Key from the Secret object.
                         type: string
+                    required:
+                    - name
+                    - key
                 oneOf:
                 - required: ['value']
                 - required: ['valueFromSecret']

--- a/config/300-webhooksource.yaml
+++ b/config/300-webhooksource.yaml
@@ -72,6 +72,9 @@ spec:
                       key:
                         description: Key from the Secret object.
                         type: string
+                    required:
+                    - name
+                    - key
                 oneOf:
                 - required: ['value']
                 - required: ['valueFromSecret']

--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -74,6 +74,9 @@ spec:
                       key:
                         description: Key from the Secret object.
                         type: string
+                    required:
+                    - name
+                    - key
                 oneOf:
                 - required: ['value']
                 - required: ['valueFromSecret']
@@ -97,6 +100,9 @@ spec:
                       key:
                         description: Key from the Secret object.
                         type: string
+                    required:
+                    - name
+                    - key
                 oneOf:
                 - required: ['value']
                 - required: ['valueFromSecret']


### PR DESCRIPTION
Identical to https://github.com/triggermesh/aws-event-sources/pull/272

It is currently possible to set a `valueFromSecret` without name or key. This is not expected.

This PR marks those fields as required in OpenAPI schemas.