### PR TITLE
Webhook: propagate content-type

### DIFF
--- a/pkg/adapter/webhooksource/webhook.go
+++ b/pkg/adapter/webhooksource/webhook.go
@@ -126,7 +126,7 @@ func (h *webhookHandler) handleAll(w http.ResponseWriter, r *http.Request) {
 	event.SetType(h.eventType)
 	event.SetSource(h.eventSource)
 
-	if err := event.SetData(cloudevents.ApplicationJSON, body); err != nil {
+	if err := event.SetData(r.Header.Get("Content-Type"), body); err != nil {
 		h.handleError(fmt.Errorf("failed to set event data: %w", err), http.StatusInternalServerError, w)
 		return
 	}
@@ -135,7 +135,6 @@ func (h *webhookHandler) handleAll(w http.ResponseWriter, r *http.Request) {
 		h.handleError(fmt.Errorf("could not send Cloud Event: %w", result), http.StatusInternalServerError, w)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 }
 


### PR DESCRIPTION
Webhook source incorrectly assumed that the payload to be sent to the sink was JSON.
This PR propagates the incoming request's Content-Type to the event's media type.

