### PR TITLE
Document OpenAPI schema for ZendeskSource

### DIFF
--- a/config/300-zendesksource.yaml
+++ b/config/300-zendesksource.yaml
@@ -17,10 +17,10 @@ kind: CustomResourceDefinition
 metadata:
   name: zendesksources.sources.triggermesh.io
   labels:
-    eventing.knative.dev/source: "true"
-    duck.knative.dev/source: "true"
-    knative.dev/crd-install: "true"
-    triggermesh.io/crd-install: "true"
+    eventing.knative.dev/source: 'true'
+    duck.knative.dev/source: 'true'
+    knative.dev/crd-install: 'true'
+    triggermesh.io/crd-install: 'true'
   annotations:
     registry.knative.dev/eventTypes: |
       [
@@ -45,6 +45,7 @@ spec:
       status: {}
     schema:
       openAPIV3Schema:
+        description: TriggerMesh event source for Zendesk.
         type: object
         properties:
           spec:
@@ -56,17 +57,17 @@ spec:
                 type: string
                 pattern: ^[a-z0-9][a-z0-9-]+[a-z0-9]$
               email:
-                description: Email of the Zendesk user to authenticate as.
+                description: Email of the Zendesk user to authenticate requests to the Zendesk API.
                 type: string
               token:
-                description: Zendesk API token.
+                description: Zendesk API token. Allows the source to interact with the Zendesk API.
                 type: object
                 properties:
                   value:
-                    description: API token in plain text.
+                    description: Literal value of the API token.
                     type: string
                   valueFromSecret:
-                    description: A reference to a Secret containing the API token.
+                    description: A reference to a Kubernetes Secret containing the API token.
                     type: object
                     properties:
                       name:
@@ -79,20 +80,20 @@ spec:
                     - name
                     - key
                 oneOf:
-                - required: ['value']
-                - required: ['valueFromSecret']
+                - required: [value]
+                - required: [valueFromSecret]
               webhookUsername:
-                description: User name for the webhook's Basic Authentication.
+                description: User name Zendesk requests must set to authenticate with the webhook using HTTP Basic authentication.
                 type: string
               webhookPassword:
-                description: Password for the webhook's Basic Authentication.
+                description: Password Zendesk requests must set to authenticate with the webhook using HTTP Basic authentication.
                 type: object
                 properties:
                   value:
-                    description: Webhook password in plain text.
+                    description: Literal value of the password.
                     type: string
                   valueFromSecret:
-                    description: A reference to a Secret containing the webhook password.
+                    description: A reference to a Kubernetes Secret object containing the password.
                     type: object
                     properties:
                       name:
@@ -105,64 +106,48 @@ spec:
                     - name
                     - key
                 oneOf:
-                - required: ['value']
-                - required: ['valueFromSecret']
+                - required: [value]
+                - required: [valueFromSecret]
               sink:
-                description: Reference to an event sink.
+                description: The destination of events generated from requests to the Zendesk webhook.
                 type: object
                 properties:
                   ref:
-                    description: Reference of an Addressable object acting as event sink.
+                    description: Reference to an addressable Kubernetes object to be used as the destination of events.
                     type: object
                     properties:
                       apiVersion:
-                        description: API version of the referent.
                         type: string
                       kind:
-                        description: Kind of the referent.
                         type: string
                       namespace:
-                        description: Namespace of the referent.
                         type: string
                       name:
-                        description: Name of the referent
                         type: string
                     required:
                     - apiVersion
                     - kind
                     - name
                   uri:
-                    description: URI of the event sink.
+                    description: URI to use as the destination of events.
                     type: string
                     format: uri
                 oneOf:
-                - required: ['ref']
-                - required: ['uri']
-              ceOverrides:
-                description: Overrides for the attributes of CloudEvents generated by the
-                  source.
-                type: object
-                properties:
-                  extensions:
-                    description: Map of CloudEvents attributes to be added or overridden.
-                    type: object
-                    additionalProperties:
-                      type: string
-                      minLength: 1
-                required:
-                - extensions
+                - required: [ref]
+                - required: [uri]
             required:
-            - sink
             - subdomain
             - email
             - token
             - webhookUsername
             - webhookPassword
+            - sink
           status:
-            description: Status of the event source.
+            description: Reported status of the event source.
             type: object
             properties:
               sinkUri:
+                description: URI of the sink where events are currently sent to.
                 type: string
                 format: uri
               ceAttributes:
@@ -204,6 +189,7 @@ spec:
                   - type
                   - status
               address:
+                description: Public address of the HTTP/S endpoint that is subscribed for receiving Zendesk webhhook events.
                 type: object
                 properties:
                   url:


### PR DESCRIPTION
Part of #143

---

Demo :

(just printing the top level spec, please check locally for yourself if you're interested in printing the doc for sub-attributes)

```console
$ kubectl explain zendesksources.spec
KIND:     ZendeskSource
VERSION:  sources.triggermesh.io/v1alpha1

RESOURCE: spec <Object>

DESCRIPTION:
     Desired state of the event source.

FIELDS:
   email        <string> -required-
     Email of the Zendesk user to authenticate requests to the Zendesk API.

   sink <Object> -required-
     The destination of events generated from requests to the Zendesk webhook.

   subdomain    <string> -required-
     Name of the Zendesk subdomain.

   token        <Object> -required-
     Zendesk API token. Allows the source to interact with the Zendesk API.

   webhookPassword      <Object> -required-
     Password Zendesk requests must set to authenticate with the webhook using
     HTTP Basic authentication.

   webhookUsername      <string> -required-
     User name Zendesk requests must set to authenticate with the webhook using
     HTTP Basic authentication.
```