### PR TITLE
Remove empty ClusterRoles

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -176,30 +176,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: httppollersource-adapter
-rules: []
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: slacksource-adapter
-rules: []
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: webhooksource-adapter
-rules: []
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
   name: zendesksource-adapter
 rules:
 

--- a/config/202-clusterrolebindings.yaml
+++ b/config/202-clusterrolebindings.yaml
@@ -37,45 +37,6 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: httppollersource-adapter
-subjects:
-- kind: ServiceAccount
-  name: knative-sources-controller
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: httppollersource-adapter
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: slacksource-adapter
-subjects:
-- kind: ServiceAccount
-  name: knative-sources-controller
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: slacksource-adapter
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: webhooksource-adapter
-subjects:
-- kind: ServiceAccount
-  name: knative-sources-controller
-  namespace: triggermesh
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: webhooksource-adapter
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
   name: zendesksource-adapter
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Same as https://github.com/triggermesh/aws-event-sources/pull/338

All these `ClusterRoles`/`ClusterRoleBindings` were originally added for consistency, but `ZendeskSource` is the only source which adapter interacts with the Kubernetes API, so I don't see any reason to keep creating these empty objects. It just creates noise.