### PR TITLE
Revert "Remove empty ClusterRoles"

### DIFF
--- a/config/200-clusterroles.yaml
+++ b/config/200-clusterroles.yaml
@@ -176,6 +176,30 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: httppollersource-adapter
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: slacksource-adapter
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: webhooksource-adapter
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: zendesksource-adapter
 rules:
 


### PR DESCRIPTION
Controllers try to bind ServiceAccounts to a Role unconditionally in `(*pkg/reconciler/common.GenericDeploymentReconciler).reconcileRBAC()`, so we need these empty roles.